### PR TITLE
[MAINT] Fix (?) release workflow

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -2,9 +2,7 @@
 
 name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 
-on:
-  push:
-    branches: ['main']
+on: push
 
 jobs:
   build:


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
- Closes #
-->

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
So I think (but am not 100% sure) that I messed up the [release workflow file](https://github.com/nipoppy/nipoppy/blob/96bc16237db7b0c9527e9f8ed675396c7550e2be/.github/workflows/build_and_publish.yml#L7) because it restricted runs on pushes to the `main` branch, but from what I can tell the tags are not pushed to `main`. @Remi-Gau is that correct? This is what I am suspecting because I ran the following locally and it didn't seem to trigger the workflow (though the tag showed up on GitHub):
```console
git tag 0.2.0
git push upstream tag 0.2.0
```

So this PR makes the GitHub Actions workflow run on all pushes instead of just pushes to `main`.

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions
