### PR TITLE
[ENH] add version to cli

### DIFF
--- a/nipoppy_cli/docs/source/conf.py
+++ b/nipoppy_cli/docs/source/conf.py
@@ -4,6 +4,8 @@ For the full list of built-in configuration values, see the documentation:
 https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 
+from nipoppy._version import __version__
+
 # for substitutions
 from nipoppy.layout import DEFAULT_LAYOUT_INFO
 
@@ -13,6 +15,16 @@ from nipoppy.layout import DEFAULT_LAYOUT_INFO
 project = "Nipoppy"
 copyright = "2024, NeuroDataScience-ORIGAMI Lab"
 author = "NeuroDataScience-ORIGAMI Lab"
+
+# The version info for the project you're documenting, acts as replacement
+# for |version| and |release|, also used in various other places throughout
+# the built documents.
+#
+# The short X.Y version.
+version = __version__
+
+# The full version, including alpha/beta/rc tags.
+release = __version__
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -126,6 +138,7 @@ myst_substitutions = {
 autodoc_typehints = "description"
 
 autoapi_dirs = ["../../nipoppy"]
+autoapi_ignore = ["*_version*", "*/cli/*"]
 autoapi_options = [
     "members",
     "undoc-members",
@@ -141,6 +154,8 @@ autoapi_template_dir = "_templates/autoapi"
 
 # ignore some auto doc related warnings
 #  see https://github.com/sphinx-doc/sphinx/issues/10785
+# suppress_warnings = ["autoapi"]
+
 nitpick_ignore = [
     ("py:class", "Path"),
     ("py:class", "optional"),

--- a/nipoppy_cli/nipoppy/cli/parser.py
+++ b/nipoppy_cli/nipoppy/cli/parser.py
@@ -4,6 +4,7 @@ import logging
 from argparse import ArgumentParser, HelpFormatter, _ActionsContainer, _SubParsersAction
 from pathlib import Path
 
+from nipoppy._version import __version__
 from nipoppy.env import BIDS_SESSION_PREFIX, BIDS_SUBJECT_PREFIX
 
 PROGRAM_NAME = "nipoppy"
@@ -118,6 +119,17 @@ def add_arg_help(parser: _ActionsContainer) -> _ActionsContainer:
         "--help",
         action="help",
         help="Show this help message and exit.",
+    )
+    return parser
+
+
+def add_arg_version(parser: _ActionsContainer) -> _ActionsContainer:
+    """Add a --version argument to the parser."""
+    parser.add_argument(
+        "--version",
+        action="version",
+        help="Show version number and exit.",
+        version=f"{__version__}",
     )
     return parser
 
@@ -306,6 +318,7 @@ def get_global_parser(
         add_help=False,
     )
     add_arg_help(global_parser)
+    add_arg_version(global_parser)
 
     # subcommand parsers
     subparsers = global_parser.add_subparsers(

--- a/nipoppy_cli/tests/test_parser.py
+++ b/nipoppy_cli/tests/test_parser.py
@@ -10,6 +10,7 @@ from nipoppy.cli.parser import (
     add_arg_pipeline_step,
     add_arg_simulate,
     add_arg_verbosity,
+    add_arg_version,
     add_args_participant_and_session,
     add_args_pipeline,
     add_subparser_bids_conversion,
@@ -27,6 +28,15 @@ def test_add_arg_dataset_root(dataset_root: str):
     parser = ArgumentParser()
     parser = add_arg_dataset_root(parser)
     assert parser.parse_args(["--dataset-root", dataset_root])
+
+
+def test_add_arg_version():
+    parser = ArgumentParser()
+    parser = add_arg_version(parser)
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        parser.parse_args(["--version"])
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == 0
 
 
 def test_add_arg_simulate():


### PR DESCRIPTION
- Closes #318
- Closes #309

Changes proposed in this pull request:

- remove warning in doc build by ignoring version and cli modules from the doc build
- add a `--version` action to the CLI
- add version to doc

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions
