### PR TITLE
[ENH] add automatic release notes for GitHub.

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,9 @@ changelog:
       - pre-commit-ci
       - dependabot[bot]
   categories:
+    - title: Breaking Changes
+      labels:
+        - P.0 - Breaking change
     - title: Features
       labels:
         - T.1 - Enhancement

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+changelog:
+  exclude:
+    authors:
+      - pre-commit-ci
+      - dependabot[bot]
+  categories:
+    - title: Features
+      labels:
+        - T.1 - Enhancement
+    - title: Bug Fixes
+      labels:
+        - T.0 - Bug
+    - title: Deprecations
+      labels:
+        - T.5 - Deprecation
+    - title: Documentation
+      labels:
+        - T.3 - Documentation
+    - title: Maintenance
+      labels:
+        - T.2 - Maintenance
+        - T.4 - Testing
+    - title: Misc
+      labels:
+        - "*"

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -100,7 +100,7 @@ jobs:
         gh release create
         '${{ github.ref_name }}'
         --repo '${{ github.repository }}'
-        --notes ""
+        --generate-notes
     - name: Upload artifact signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #315 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- 
Create a release template as shown [here](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes)

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] ~~Tests pass~~
- [ ] Checks pass

For new features:
- [ ] ~~Tests have been added~~

For bug fixes:
- [ ] ~~There is at least one test that would fail under the original bug conditions~~
