### PR TITLE
[BUG] Fix error when using invalid verbosity level

### DIFF
--- a/nipoppy_cli/nipoppy/cli/parser.py
+++ b/nipoppy_cli/nipoppy/cli/parser.py
@@ -1,7 +1,13 @@
 """Parsers for the CLI."""
 
 import logging
-from argparse import ArgumentParser, HelpFormatter, _ActionsContainer, _SubParsersAction
+from argparse import (
+    ArgumentError,
+    ArgumentParser,
+    HelpFormatter,
+    _ActionsContainer,
+    _SubParsersAction,
+)
 from pathlib import Path
 
 from nipoppy._version import __version__
@@ -141,15 +147,19 @@ def add_arg_verbosity(parser: _ActionsContainer) -> _ActionsContainer:
         try:
             return VERBOSITY_TO_LOG_LEVEL_MAP[verbosity]
         except KeyError:
-            parser.error(
-                f"Invalid verbosity level: {verbosity}."
-                f" Valid levels are {list(VERBOSITY_TO_LOG_LEVEL_MAP.keys())}."
+            raise ArgumentError(
+                None,
+                (
+                    f"Invalid verbosity level: {verbosity}. "
+                    f"Valid levels are: {', '.join(VERBOSITY_TO_LOG_LEVEL_MAP.keys())}."
+                ),
             )
 
     parser.add_argument(
         "--verbosity",
         type=_verbosity_to_log_level,
         default=DEFAULT_VERBOSITY,
+        metavar=f"{{{','.join(VERBOSITY_TO_LOG_LEVEL_MAP.keys())}}}",  # show choices
         help=(
             "Verbosity level, from 0 (least verbose) to 3 (most verbose)."
             f" Default: {DEFAULT_VERBOSITY}."

--- a/nipoppy_cli/nipoppy/cli/parser.py
+++ b/nipoppy_cli/nipoppy/cli/parser.py
@@ -1,13 +1,7 @@
 """Parsers for the CLI."""
 
 import logging
-from argparse import (
-    ArgumentError,
-    ArgumentParser,
-    HelpFormatter,
-    _ActionsContainer,
-    _SubParsersAction,
-)
+from argparse import ArgumentParser, HelpFormatter, _ActionsContainer, _SubParsersAction
 from pathlib import Path
 
 from nipoppy._version import __version__
@@ -142,24 +136,10 @@ def add_arg_version(parser: _ActionsContainer) -> _ActionsContainer:
 
 def add_arg_verbosity(parser: _ActionsContainer) -> _ActionsContainer:
     """Add a --verbosity argument to the parser."""
-
-    def _verbosity_to_log_level(verbosity: str):
-        try:
-            return VERBOSITY_TO_LOG_LEVEL_MAP[verbosity]
-        except KeyError:
-            raise ArgumentError(
-                None,
-                (
-                    f"Invalid verbosity level: {verbosity}. "
-                    f"Valid levels are: {', '.join(VERBOSITY_TO_LOG_LEVEL_MAP.keys())}."
-                ),
-            )
-
     parser.add_argument(
         "--verbosity",
-        type=_verbosity_to_log_level,
         default=DEFAULT_VERBOSITY,
-        metavar=f"{{{','.join(VERBOSITY_TO_LOG_LEVEL_MAP.keys())}}}",  # show choices
+        choices=VERBOSITY_TO_LOG_LEVEL_MAP.keys(),
         help=(
             "Verbosity level, from 0 (least verbose) to 3 (most verbose)."
             f" Default: {DEFAULT_VERBOSITY}."

--- a/nipoppy_cli/nipoppy/cli/run.py
+++ b/nipoppy_cli/nipoppy/cli/run.py
@@ -13,6 +13,7 @@ from nipoppy.cli.parser import (
     COMMAND_INIT,
     COMMAND_PIPELINE_RUN,
     COMMAND_PIPELINE_TRACK,
+    VERBOSITY_TO_LOG_LEVEL_MAP,
     get_global_parser,
 )
 from nipoppy.logger import add_logfile, capture_warnings, get_logger
@@ -28,7 +29,7 @@ def cli(argv: Sequence[str] = None) -> None:
     # common arguments
     command = args.command
     fpath_layout = args.fpath_layout
-    logger = get_logger(name=command, level=args.verbosity)
+    logger = get_logger(name=command, level=VERBOSITY_TO_LOG_LEVEL_MAP[args.verbosity])
     dry_run = args.dry_run
 
     # to pass to all workflows

--- a/nipoppy_cli/tests/test_parser.py
+++ b/nipoppy_cli/tests/test_parser.py
@@ -92,15 +92,14 @@ def test_add_arg_verbosity(verbosity):
     assert parser.parse_args(["--verbosity", verbosity])
 
 
-@pytest.mark.parametrize("verbosity", ["4", "x"])
-def test_add_arg_verbosity_invalid(verbosity, capsys: pytest.CaptureFixture):
+def test_add_arg_verbosity_invalid(capsys: pytest.CaptureFixture):
     parser = ArgumentParser()
     parser = add_arg_verbosity(parser)
     with pytest.raises(SystemExit) as exception:
-        parser.parse_args(["--verbosity", verbosity])
+        parser.parse_args(["--verbosity", "4"])
 
     captured = capsys.readouterr()
-    assert "Invalid verbosity level" in captured.err
+    assert "invalid choice" in captured.err
     assert exception.value.code != 0, "Parsing of invalid argument should fail."
 
 
@@ -256,22 +255,3 @@ def test_global_parser(args: list[str]):
         assert (
             exception.code == 0
         ), "Expect exit code of 0 if program exited while parsing."
-
-
-@pytest.mark.parametrize(
-    "args",
-    [
-        ["init", "--dataset-root", "my_dataset", "--verbosity", "5"],
-        ["run", "--dataset-root", "my_other_dataset", "--verbosity", "4"],
-    ],
-)
-def test_global_parser_invalid_verbosity(
-    args: list[str], capsys: pytest.CaptureFixture
-):
-    parser = get_global_parser()
-    with pytest.raises(SystemExit) as exception:
-        parser.parse_args(args)
-
-    captured = capsys.readouterr()
-    assert "Invalid verbosity level" in captured.err
-    assert exception.value.code != 0, "Parsing of invalid argument should fail."

--- a/nipoppy_cli/tests/test_parser.py
+++ b/nipoppy_cli/tests/test_parser.py
@@ -93,11 +93,14 @@ def test_add_arg_verbosity(verbosity):
 
 
 @pytest.mark.parametrize("verbosity", ["4", "x"])
-def test_add_arg_verbosity_invalid(verbosity):
+def test_add_arg_verbosity_invalid(verbosity, capsys: pytest.CaptureFixture):
     parser = ArgumentParser()
     parser = add_arg_verbosity(parser)
     with pytest.raises(SystemExit) as exception:
-        parser.parse_args(["verbosity", verbosity])
+        parser.parse_args(["--verbosity", verbosity])
+
+    captured = capsys.readouterr()
+    assert "Invalid verbosity level" in captured.err
     assert exception.value.code != 0, "Parsing of invalid argument should fail."
 
 
@@ -253,3 +256,22 @@ def test_global_parser(args: list[str]):
         assert (
             exception.code == 0
         ), "Expect exit code of 0 if program exited while parsing."
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["init", "--dataset-root", "my_dataset", "--verbosity", "5"],
+        ["run", "--dataset-root", "my_other_dataset", "--verbosity", "4"],
+    ],
+)
+def test_global_parser_invalid_verbosity(
+    args: list[str], capsys: pytest.CaptureFixture
+):
+    parser = get_global_parser()
+    with pytest.raises(SystemExit) as exception:
+        parser.parse_args(args)
+
+    captured = capsys.readouterr()
+    assert "Invalid verbosity level" in captured.err
+    assert exception.value.code != 0, "Parsing of invalid argument should fail."


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #328

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Make existing test more robust (though it does not test subparsers which was the cause of the original error)
- Add new test for subparsers

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions
