### PR TITLE
[BUG] Fix logging issues

### DIFF
--- a/nipoppy/cli/run.py
+++ b/nipoppy/cli/run.py
@@ -13,6 +13,7 @@ from nipoppy.cli.parser import (
     COMMAND_INIT,
     COMMAND_PIPELINE_RUN,
     COMMAND_PIPELINE_TRACK,
+    PROGRAM_NAME,
     VERBOSITY_TO_LOG_LEVEL_MAP,
     get_global_parser,
 )
@@ -29,7 +30,10 @@ def cli(argv: Sequence[str] = None) -> None:
     # common arguments
     command = args.command
     fpath_layout = args.fpath_layout
-    logger = get_logger(name=command, level=VERBOSITY_TO_LOG_LEVEL_MAP[args.verbosity])
+    logger = get_logger(
+        name=f"{PROGRAM_NAME}.{command}",
+        level=VERBOSITY_TO_LOG_LEVEL_MAP[args.verbosity],
+    )
     dry_run = args.dry_run
 
     # to pass to all workflows

--- a/nipoppy/env.py
+++ b/nipoppy/env.py
@@ -1,6 +1,7 @@
 """Variable Definitions."""
 
 import os
+import sys
 from typing import TypeVar
 
 StrOrPathLike = TypeVar("StrOrPathLike", str, os.PathLike)
@@ -8,6 +9,8 @@ StrOrPathLike = TypeVar("StrOrPathLike", str, os.PathLike)
 # BIDS
 BIDS_SUBJECT_PREFIX = "sub-"
 BIDS_SESSION_PREFIX = "ses-"
+
+IS_TESTING = "pytest" in sys.modules
 
 
 class ReturnCode:

--- a/nipoppy/logger.py
+++ b/nipoppy/logger.py
@@ -8,7 +8,7 @@ from typing import Optional
 from rich.console import Console
 from rich.logging import RichHandler
 
-from nipoppy.env import StrOrPathLike
+from nipoppy.env import IS_TESTING, StrOrPathLike
 
 DATE_FORMAT = "[%Y-%m-%d %X]"
 FORMAT_RICH = "%(message)s"
@@ -22,6 +22,11 @@ def get_logger(
     # create logger
     logger = logging.getLogger(name=name)
     logger.setLevel(level)
+
+    # propagate should be False to avoid duplicates from root logger
+    # except when testing because otherwise pytest does not capture the logs
+    if not IS_TESTING:
+        logger.propagate = False
 
     # partially instantiate RichHandler
     rich_handler = partial(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pandas",
     "pybids",
     "pydantic",
-    "pydicom",
+    "pydicom!=3.0.0",
     "rich",
     "rich_argparse",
     "typing-extensions",

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -68,3 +68,16 @@ def test_add_logfile_mkdir(tmp_path: Path, caplog: pytest.LogCaptureFixture):
     logger.info("Test")
     assert "Creating log directory" in caplog.text
     assert fpath_log.exists()
+
+
+def test_no_extra_logs(caplog: pytest.LogCaptureFixture):
+    caplog.clear()
+
+    logger = get_logger()
+    logger.propagate = True
+
+    # doing this should not log anything
+    import nipoppy.workflows  # noqa F401
+
+    logger.info("TEST")
+    assert len(caplog.records) == 1

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+import nipoppy.logger  # for monkeypatching
 from nipoppy.logger import add_logfile, get_logger
 
 
@@ -43,6 +44,12 @@ def test_get_logger_level(level: int):
     # so we need to check the root logger to see if the level was set correctly
     logger = get_logger(level=level)
     assert logger.level == level
+
+
+def test_get_logger_no_propagate(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(nipoppy.logger, "IS_TESTING", False)
+    logger = get_logger()
+    assert not logger.propagate
 
 
 def test_add_logfile(tmp_path: Path):


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #355

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Exclude `pydicom` version `3.0.0` from dependencies
- Do not propagate Nipoppy loggers to root logger. Otherwise, if the root logger has handlers that print to stdout/stderr, they will be duplicated 
  - Note that this is disabled during testing because `pytest` relies on the propagation for the `caplog` fixture

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- ~Tests have been added~

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions
