### PR TITLE
[DOC] Add auto-generated changelog page to docs

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,0 +1,10 @@
+.. Note: This page has to be in ReST format, not Markdown
+.. because otherwise the changelog is not generated correctly
+
+What's new
+==========
+
+.. changelog::
+    :changelog-url: https://nipoppy.readthedocs.io/en/stable/changelog.html
+    :github: https://github.com/nipoppy/nipoppy/releases/
+    :pypi: https://pypi.org/project/nipoppy/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -171,6 +171,11 @@ nitpick_ignore = [
 ]
 
 # -- Sphinx Github Changelog configuration ------------------------------------
+
+# PAT needs to be set as environment variable in Read the Docs project settings
+# fine-grained token permissions:
+#   - nipoppy/nipoppy repository
+#   - read access to code + metadata
 sphinx_github_changelog_token = os.environ.get("NIPOPPY_RELEASES_PAT")
 
 # -- Copybutton configuration -------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,6 +4,8 @@ For the full list of built-in configuration values, see the documentation:
 https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 
+import os
+
 from nipoppy._version import __version__
 from nipoppy.layout import DEFAULT_LAYOUT_INFO  # for substitutions
 
@@ -32,6 +34,7 @@ extensions = [
     "myst_parser",
     "sphinxarg.ext",
     "sphinx_copybutton",
+    "sphinx_github_changelog",
     "sphinx-jsonschema",
     "sphinx_togglebutton",
     "sphinx.ext.autodoc.typehints",
@@ -166,6 +169,9 @@ nitpick_ignore = [
     ("py:class", "nipoppy.env.StrOrPathLike"),
     ("py:class", "typing_extensions.Self"),
 ]
+
+# -- Sphinx Github Changelog configuration ------------------------------------
+sphinx_github_changelog_token = os.environ.get("NIPOPPY_RELEASES_PAT")
 
 # -- Copybutton configuration -------------------------------------------------
 copybutton_exclude = ".linenos, .gp"

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -38,6 +38,7 @@ includehidden:
 titlesonly:
 caption: Other
 ---
+changelog
 contributing
 glossary
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,7 @@ build-backend = "hatchling.build"
 requires = ["hatchling", "hatch-vcs"]
 
 [project]
-authors = [
-    { name = "Michelle Wang" },
-    { name = "Nikhil Bhagwat" },
-    { name = "Brent McPherson" },
-    { name = "Rémi Gau" },
-]
+authors = [{ name = "Nipoppy developpers" }]
 classifiers = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
@@ -45,6 +40,7 @@ doc = [
     "sphinx-argparse>=0.4.0, !=0.5.0",
     "sphinx-autoapi==3.0.0",
     "sphinx-copybutton>=0.5.2",
+    "sphinx-github-changelog>=1.4.0",
     "sphinx-jsonschema>=1.19.1",
     "sphinx-togglebutton>=0.3.2",
     "mdit-py-plugins>=0.4.0",


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #360

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Add doc dependency `sphinx-github-changelog` and use it to 
- Note: New PAT with `contents` read permissions added to Readthedocs project
- Preview: https://nipoppy--361.org.readthedocs.build/en/361/changelog.html

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- ~Tests have been added~

For bug fixes:
- ~There is at least one test that would fail under the original bug conditions~
