### PR TITLE
[MAINT] Refactor pipeline step config in workflow classes

### DIFF
--- a/nipoppy/config/main.py
+++ b/nipoppy/config/main.py
@@ -14,7 +14,6 @@ from nipoppy.config.pipeline import (
     BidsPipelineConfig,
     ProcPipelineConfig,
 )
-from nipoppy.config.pipeline_step import BidsPipelineStepConfig, ProcPipelineStepConfig
 from nipoppy.env import BIDS_SESSION_PREFIX, StrOrPathLike
 from nipoppy.layout import DEFAULT_LAYOUT_INFO
 from nipoppy.tabular.dicom_dir_map import DicomDirMap
@@ -153,25 +152,6 @@ class Config(SchemaWithContainerConfig):
         self._check_dicom_dir_options()
         self._check_no_duplicate_pipeline()
 
-        # make sure BIDS/processing pipelines are the right type
-        for pipeline_configs, step_class in [
-            (self.BIDS_PIPELINES, BidsPipelineStepConfig),
-            (self.PROC_PIPELINES, ProcPipelineStepConfig),
-        ]:
-            for pipeline_config in pipeline_configs:
-                # type annotation to make IDE smarter
-                pipeline_config: BasePipelineConfig
-                steps = pipeline_config.STEPS
-                for i_step in range(len(steps)):
-                    # extract fields used to create (possibly incorrect) step object
-                    # and use them to create a new (correct) step object
-                    # (this is needed because BidsPipelineStepConfig and
-                    # ProcPipelineStepConfig share some fields, and the fields
-                    # that are different are optional, so the default Pydantic
-                    # parsing can create the wrong type of step object)
-                    steps[i_step] = step_class(
-                        **steps[i_step].model_dump(exclude_unset=True)
-                    )
         return self
 
     def get_pipeline_version(self, pipeline_name: str) -> str:
@@ -200,8 +180,8 @@ class Config(SchemaWithContainerConfig):
         self,
         pipeline_name: str,
         pipeline_version: str,
-    ) -> ProcPipelineConfig:
-        """Get the config for a BIDS or processing pipeline."""
+    ) -> BasePipelineConfig:
+        """Get the config for a pipeline."""
         # pooling them together since there should not be any duplicates
         for pipeline_config in self.PROC_PIPELINES + self.BIDS_PIPELINES:
             if (

--- a/nipoppy/config/pipeline.py
+++ b/nipoppy/config/pipeline.py
@@ -128,5 +128,15 @@ class BidsPipelineConfig(BasePipelineConfig):
 class ProcPipelineConfig(BasePipelineConfig):
     """Schema for processing pipeline configuration."""
 
+    TRACKER_CONFIG_FILE: Optional[Path] = Field(
+        default=None,
+        description=(
+            "Path to the tracker configuration file associated with the pipeline"
+            ". This file must contain a list of tracker configurations"
+            ", each of which must be a dictionary with a NAME field (string)"
+            " and a PATHS field (non-empty list of strings)"
+        ),
+    )
+
     _step_class = ProcPipelineStepConfig
     model_config = ConfigDict(extra="forbid")

--- a/nipoppy/config/pipeline.py
+++ b/nipoppy/config/pipeline.py
@@ -67,10 +67,8 @@ class BasePipelineConfig(SchemaWithContainerConfig, ABC):
         - If STEPS has more than one item, make sure that each step has a unique name.
         """
         # make sure BIDS/processing pipelines are the right type
-        for i_step in range(len(self.STEPS)):
-            self.STEPS[i_step] = self._step_class(
-                **self.STEPS[i_step].model_dump(exclude_unset=True)
-            )
+        for i_step, step in enumerate(self.STEPS):
+            self.STEPS[i_step] = self._step_class(**step.model_dump(exclude_unset=True))
 
         if len(self.STEPS) > 1:
             step_names = []

--- a/nipoppy/config/pipeline.py
+++ b/nipoppy/config/pipeline.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Optional, Type, Union
 
 from pydantic import ConfigDict, Field, model_validator
 from pydantic_core import to_jsonable_python
@@ -21,6 +21,9 @@ from nipoppy.utils import apply_substitutions_to_json
 class BasePipelineConfig(SchemaWithContainerConfig, ABC):
     """Base schema for processing/BIDS pipeline configuration."""
 
+    # for validation
+    _step_class: Type[BasePipelineStepConfig] = BasePipelineStepConfig
+
     NAME: str = Field(description="Name of the pipeline")
     VERSION: str = Field(description="Version of the pipeline")
     DESCRIPTION: Optional[str] = Field(
@@ -30,7 +33,7 @@ class BasePipelineConfig(SchemaWithContainerConfig, ABC):
         default=ContainerInfo(),
         description="Information about the container image file",
     )
-    STEPS: list[Union[ProcPipelineStepConfig, BidsPipelineStepConfig]] = Field(
+    STEPS: list[Union[BidsPipelineStepConfig, ProcPipelineStepConfig]] = Field(
         default=[],
         description="List of pipeline step configurations",
     )
@@ -60,8 +63,15 @@ class BasePipelineConfig(SchemaWithContainerConfig, ABC):
         Validate the pipeline configuration after creation.
 
         Specifically:
+        - Check that items in STEPS have the correct type.
         - If STEPS has more than one item, make sure that each step has a unique name.
         """
+        # make sure BIDS/processing pipelines are the right type
+        for i_step in range(len(self.STEPS)):
+            self.STEPS[i_step] = self._step_class(
+                **self.STEPS[i_step].model_dump(exclude_unset=True)
+            )
+
         if len(self.STEPS) > 1:
             step_names = []
             for step in self.STEPS:
@@ -107,64 +117,16 @@ class BasePipelineConfig(SchemaWithContainerConfig, ABC):
             f"Step {step_name} not found in pipeline {self.NAME} {self.VERSION}"
         )
 
-    def get_invocation_file(self, step_name: Optional[str] = None) -> Path | None:
-        """
-        Return the path to the invocation file for the given step.
-
-        Is step is None, return the invocation file for the first step.
-        """
-        return self.get_step_config(step_name).INVOCATION_FILE
-
-    def get_descriptor_file(self, step_name: Optional[str] = None) -> Path | None:
-        """
-        Return the path to the descriptor file for the given step.
-
-        If step is None, return the descriptor file for the first step.
-        """
-        return self.get_step_config(step_name).DESCRIPTOR_FILE
-
-    def get_analysis_level(self, step_name: Optional[str] = None) -> str:
-        """
-        Return the analysis level for the given step.
-
-        If step is None, return the analysis level for the first step.
-        """
-        return self.get_step_config(step_name).ANALYSIS_LEVEL
-
 
 class BidsPipelineConfig(BasePipelineConfig):
     """Schema for BIDS pipeline configuration."""
 
+    _step_class = BidsPipelineStepConfig
     model_config = ConfigDict(extra="forbid")
-
-    def get_update_doughnut(self, step_name: Optional[str] = None) -> Path | None:
-        """
-        Return the update doughnut flag for the given step.
-
-        If step is None, return the flag for the first step.
-        """
-        return self.get_step_config(step_name).UPDATE_DOUGHNUT
 
 
 class ProcPipelineConfig(BasePipelineConfig):
     """Schema for processing pipeline configuration."""
 
-    TRACKER_CONFIG_FILE: Optional[Path] = Field(
-        default=None,
-        description=(
-            "Path to the tracker configuration file associated with the pipeline"
-            ". This file must contain a list of tracker configurations"
-            ", each of which must be a dictionary with a NAME field (string)"
-            " and a PATHS field (non-empty list of strings)"
-        ),
-    )
-
+    _step_class = ProcPipelineStepConfig
     model_config = ConfigDict(extra="forbid")
-
-    def get_pybids_ignore_file(self, step_name: Optional[str] = None) -> Path | None:
-        """
-        Return the list of regex patterns to ignore when building the PyBIDS layout.
-
-        If step is None, return the patterns for the first step.
-        """
-        return self.get_step_config(step_name).PYBIDS_IGNORE_FILE

--- a/nipoppy/workflows/base.py
+++ b/nipoppy/workflows/base.py
@@ -36,10 +36,6 @@ class BaseWorkflow(Base, ABC):
     log_prefix_run_stderr = "[RUN STDERR]"
     validate_layout = True
 
-    # hack to avoid errors when loading/processing the default config
-    pipeline_name = "[[NIPOPPY_PIPELINE_NAME]]"
-    pipeline_version = "[[NIPOPPY_PIPELINE_VERSION]]"
-
     def __init__(
         self,
         dpath_root: StrOrPathLike,

--- a/nipoppy/workflows/bids_conversion.py
+++ b/nipoppy/workflows/bids_conversion.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Optional
 
 from nipoppy.config.pipeline import BidsPipelineConfig
+from nipoppy.config.pipeline_step import BidsPipelineStepConfig
 from nipoppy.env import StrOrPathLike
 from nipoppy.workflows.runner import PipelineRunner
 
@@ -50,11 +51,16 @@ class BidsConversionRunner(PipelineRunner):
 
     @cached_property
     def pipeline_config(self) -> BidsPipelineConfig:
-        """Get the user config for the BIDS conversion software."""
+        """Get the user config for the BIDS conversion pipeline."""
         return self.config.get_pipeline_config(
             self.pipeline_name,
             self.pipeline_version,
         )
+
+    @cached_property
+    def pipeline_step_config(self) -> BidsPipelineStepConfig:
+        """Get the config for the relevant step of the BIDS conversion pipeline."""
+        return super().pipeline_step_config
 
     def get_participants_sessions_to_run(
         self, participant_id: Optional[str], session_id: Optional[str]
@@ -105,9 +111,7 @@ class BidsConversionRunner(PipelineRunner):
         Specifically:
         - Write updated doughnut file
         """
-        update_doughnut = self.pipeline_config.get_update_doughnut(
-            step_name=self.pipeline_step
-        )
+        update_doughnut = self.pipeline_step_config.UPDATE_DOUGHNUT
         if update_doughnut and not self.simulate:
             self.save_tabular_file(self.doughnut, self.layout.fpath_doughnut)
         return super().run_cleanup(**kwargs)

--- a/nipoppy/workflows/pipeline.py
+++ b/nipoppy/workflows/pipeline.py
@@ -360,11 +360,20 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
                 f"Pipeline version not specified, using version {self.pipeline_version}"
             )
 
+    def check_pipeline_step(self):
+        """Set the pipeline step name based on the config if it is not given."""
+        if self.pipeline_step is None:
+            self.pipeline_step = self.pipeline_step_config.NAME
+            self.logger.warning(
+                f"Pipeline step not specified, using step {self.pipeline_step}"
+            )
+
     def run_setup(self):
         """Run pipeline setup."""
         to_return = super().run_setup()
 
         self.check_pipeline_version()
+        self.check_pipeline_step()
 
         for dpath in self.dpaths_to_check:
             self.check_dir(dpath)

--- a/nipoppy/workflows/pipeline.py
+++ b/nipoppy/workflows/pipeline.py
@@ -18,7 +18,7 @@ from nipoppy.config.boutiques import (
     get_boutiques_config_from_descriptor,
 )
 from nipoppy.config.pipeline import ProcPipelineConfig
-from nipoppy.config.pipeline_step import AnalysisLevelType
+from nipoppy.config.pipeline_step import AnalysisLevelType, ProcPipelineStepConfig
 from nipoppy.env import (
     BIDS_SESSION_PREFIX,
     BIDS_SUBJECT_PREFIX,
@@ -148,6 +148,11 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
         )
 
     @cached_property
+    def pipeline_step_config(self) -> ProcPipelineStepConfig:
+        """Get the user config for the pipeline step."""
+        return self.pipeline_config.get_step_config(step_name=self.pipeline_step)
+
+    @cached_property
     def fpath_container(self) -> Path:
         """Return the full path to the pipeline's container."""
         fpath_container = self.pipeline_config.get_fpath_container()
@@ -167,9 +172,7 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
     @cached_property
     def descriptor(self) -> dict:
         """Load the pipeline step's Boutiques descriptor."""
-        fpath_descriptor = self.pipeline_config.get_descriptor_file(
-            step_name=self.pipeline_step
-        )
+        fpath_descriptor = self.pipeline_step_config.DESCRIPTOR_FILE
         if fpath_descriptor is None:
             raise ValueError(
                 "No descriptor file specified for pipeline"
@@ -183,9 +186,7 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
     @cached_property
     def invocation(self) -> dict:
         """Load the pipeline step's Boutiques invocation."""
-        fpath_invocation = self.pipeline_config.get_invocation_file(
-            step_name=self.pipeline_step
-        )
+        fpath_invocation = self.pipeline_step_config.INVOCATION_FILE
         if fpath_invocation is None:
             raise ValueError(
                 "No invocation file specified for pipeline"
@@ -204,9 +205,7 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
         Note: this does not apply any substitutions, since the subject/session
         patterns are always added.
         """
-        fpath_pybids_ignore = self.pipeline_config.get_pybids_ignore_file(
-            step_name=self.pipeline_step
-        )
+        fpath_pybids_ignore = self.pipeline_step_config.PYBIDS_IGNORE_FILE
 
         # no file specified
         if fpath_pybids_ignore is None:
@@ -378,15 +377,9 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
             self.participant_id, self.session_id
         )
 
-        # trackers are at pipeline level, not pipeline step level
-        # but this will probably change in the future
-        try:
-            analysis_level = self.pipeline_config.get_analysis_level(self.pipeline_step)
-        except ValueError:
-            analysis_level = AnalysisLevelType.participant_session
         participants_sessions = apply_analysis_level(
             participants_sessions=participants_sessions,
-            analysis_level=analysis_level,
+            analysis_level=self.pipeline_step_config.ANALYSIS_LEVEL,
         )
 
         for participant_id, session_id in participants_sessions:
@@ -426,10 +419,7 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
             else:
                 color = LogColor.PARTIAL_SUCCESS
 
-            if (
-                self.pipeline_config.get_analysis_level(self.pipeline_step)
-                == AnalysisLevelType.group
-            ):
+            if self.pipeline_step_config.ANALYSIS_LEVEL == AnalysisLevelType.group:
                 message_body = "on the entire study"
             else:
                 message_body = (

--- a/nipoppy/workflows/runner.py
+++ b/nipoppy/workflows/runner.py
@@ -161,6 +161,7 @@ class PipelineRunner(BasePipelineWorkflow):
         to the bagel file.
         """
         self.check_pipeline_version()  # in case this is called outside of run()
+        self.check_pipeline_step()
         if self.layout.fpath_imaging_bagel.exists():
             bagel = Bagel.load(self.layout.fpath_imaging_bagel)
             participants_sessions_completed = set(

--- a/tests/test_workflow_pipeline.py
+++ b/tests/test_workflow_pipeline.py
@@ -534,6 +534,37 @@ def test_check_pipeline_version(
     assert f"using version {expected_version}" in caplog.text
 
 
+@pytest.mark.parametrize(
+    "pipeline_name,pipeline_version,expected_step",
+    [
+        ("heudiconv", "0.12.2", "prepare"),
+        ("fmriprep", "23.1.3", None),
+        ("my_pipeline", "1.0", None),
+    ],
+)
+def test_check_pipeline_step(
+    pipeline_name,
+    pipeline_version,
+    expected_step,
+    workflow: PipelineWorkflow,
+    caplog: pytest.LogCaptureFixture,
+):
+    workflow.pipeline_name = pipeline_name
+    workflow.pipeline_version = pipeline_version
+    workflow.check_pipeline_step()
+    assert workflow.pipeline_step == expected_step
+    assert f"using step {expected_step}" in caplog.text
+
+
+def test_run_setup_pipeline_version_step(workflow: PipelineWorkflow):
+    workflow.pipeline_version = None
+    workflow.pipeline_step = None
+    create_empty_dataset(workflow.layout.dpath_root)
+    workflow.run_setup()
+    assert workflow.pipeline_version == "1.0"
+    assert workflow.pipeline_step is None
+
+
 @pytest.mark.parametrize("dry_run", [True, False])
 def test_run_setup_create_directories(dry_run: bool, tmp_path: Path):
     workflow = PipelineWorkflow(
@@ -543,6 +574,15 @@ def test_run_setup_create_directories(dry_run: bool, tmp_path: Path):
         dry_run=dry_run,
     )
     create_empty_dataset(workflow.layout.dpath_root)
+    get_config(
+        proc_pipelines=[
+            ProcPipelineConfig(
+                NAME=workflow.pipeline_name,
+                VERSION=workflow.pipeline_version,
+                STEPS=[ProcPipelineStepConfig()],
+            )
+        ]
+    ).save(workflow.layout.fpath_config)
     workflow.run_setup()
     assert workflow.dpath_pipeline.exists() == (not dry_run)
 

--- a/tests/test_workflow_pipeline.py
+++ b/tests/test_workflow_pipeline.py
@@ -234,7 +234,7 @@ def test_descriptor(
 
     # user-added pipelines with descriptor file
     fpath_descriptor = tmp_path / "custom_pipeline.json"
-    workflow.pipeline_config.get_step_config().DESCRIPTOR_FILE = fpath_descriptor
+    workflow.pipeline_step_config.DESCRIPTOR_FILE = fpath_descriptor
     fpath_descriptor.write_text(json.dumps(descriptor))
     assert workflow.descriptor == descriptor
 
@@ -290,7 +290,7 @@ def test_invocation(
     fpath_invocation = tmp_path / "invocation.json"
     fpath_invocation.write_text(json.dumps(invocation))
 
-    workflow.pipeline_config.get_step_config().INVOCATION_FILE = fpath_invocation
+    workflow.pipeline_step_config.INVOCATION_FILE = fpath_invocation
     assert workflow.invocation == invocation
 
 
@@ -343,7 +343,7 @@ def test_pybids_ignore_patterns(
 
     fpath_patterns = tmp_path / "pybids_ignore_patterns.json"
     fpath_patterns.write_text(json.dumps(patterns))
-    workflow.pipeline_config.get_step_config().PYBIDS_IGNORE_FILE = fpath_patterns
+    workflow.pipeline_step_config.PYBIDS_IGNORE_FILE = fpath_patterns
 
     assert workflow.pybids_ignore_patterns == [
         re.compile(pattern) for pattern in patterns
@@ -351,7 +351,7 @@ def test_pybids_ignore_patterns(
 
 
 def test_pybids_ignore_patterns_no_file(workflow: PipelineWorkflow):
-    workflow.pipeline_config.get_step_config().PYBIDS_IGNORE_FILE = None
+    workflow.pipeline_step_config.PYBIDS_IGNORE_FILE = None
     assert workflow.pybids_ignore_patterns == []
 
 
@@ -360,7 +360,7 @@ def test_pybids_ignore_patterns_invalid_format(
 ):
     fpath_patterns = tmp_path / "pybids_ignore_patterns.json"
     fpath_patterns.write_text(json.dumps({"key": "value"}))
-    workflow.pipeline_config.get_step_config().PYBIDS_IGNORE_FILE = fpath_patterns
+    workflow.pipeline_step_config.PYBIDS_IGNORE_FILE = fpath_patterns
 
     with pytest.raises(ValueError, match="Expected a list of strings"):
         workflow.pybids_ignore_patterns

--- a/tests/test_workflow_tracker.py
+++ b/tests/test_workflow_tracker.py
@@ -58,6 +58,7 @@ def tracker(tmp_path: Path):
                 "NAME": pipeline_name,
                 "VERSION": pipeline_version,
                 "TRACKER_CONFIG_FILE": fpath_tracker_config,
+                "STEPS": [{}],
             },
         ],
     )


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes none
- Extracted from #352 which is too big

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Previously, `BasePipelineStep` objects had a `get_step_config(pipeline_step)` method to get the config for a specific pipeline step and a bunch of getter functions that wrapped around it to get step attributes. This was in workflows because every time we needed to access a field in a pipeline step config, we had to call one of the getters and provide the pipeline step name, which is fixed
- This PR is a refactor that adds a `pipeline_step_config` property to workflow objects, similar to `pipeline_config`

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- ~Tests have been added~

For bug fixes:
- ~There is at least one test that would fail under the original bug conditions~
