### PR TITLE
[FIX] Support latest version of doc dependencies

### DIFF
--- a/docs/source/_templates/autoapi/index.rst
+++ b/docs/source/_templates/autoapi/index.rst
@@ -6,10 +6,8 @@ This page contains auto-generated API reference documentation [#f1]_.
 .. toctree::
    :titlesonly:
 
-   {% for page in pages %}
-   {% if page.top_level_object and page.display %}
+   {% for page in pages|selectattr("is_top_level_object") %}
    {{ page.include_path }}
-   {% endif %}
    {% endfor %}
 
 .. [#f1] Created with `sphinx-autoapi <https://github.com/readthedocs/sphinx-autoapi>`_

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -144,13 +144,13 @@ autoapi_options = [
     "members",
     "undoc-members",
     # "private-members",
-    "show-inheritance",
+    # "show-inheritance",
     # "show-module-summary",
     # "special-members",
     "imported-members",
 ]
 autoapi_member_order = "groupwise"
-autoapi_own_page_level = "module"
+autoapi_own_page_level = "class"
 autoapi_template_dir = "_templates/autoapi"
 
 # ignore some auto doc related warnings
@@ -168,6 +168,11 @@ nitpick_ignore = [
     ("py:class", "StrOrPathLike"),
     ("py:class", "nipoppy.env.StrOrPathLike"),
     ("py:class", "typing_extensions.Self"),
+    ("py:obj", "BasePipelineConfig"),
+    ("py:obj", "BasePipelineStepConfig"),
+    ("py:obj", "ContainerConfig"),
+    ("py:obj", "PathInfo"),
+    ("py:obj", "FpathInfo"),
 ]
 
 # -- Sphinx Github Changelog configuration ------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -150,7 +150,7 @@ autoapi_options = [
     "imported-members",
 ]
 autoapi_member_order = "groupwise"
-autoapi_own_page_level = "class"
+autoapi_own_page_level = "module"
 autoapi_template_dir = "_templates/autoapi"
 
 # ignore some auto doc related warnings

--- a/nipoppy/config/boutiques.py
+++ b/nipoppy/config/boutiques.py
@@ -2,13 +2,13 @@
 
 from pydantic import ConfigDict, Field
 
-from nipoppy.config.container import SchemaWithContainerConfig
+from nipoppy.config.container import _SchemaWithContainerConfig
 
 BOUTIQUES_CUSTOM_KEY = "custom"  # as defined by Boutiques schema
 BOUTIQUES_CONFIG_KEY = "nipoppy"
 
 
-class BoutiquesConfig(SchemaWithContainerConfig):
+class BoutiquesConfig(_SchemaWithContainerConfig):
     """Schema for custom configuration within a Boutiques descriptor."""
 
     CONTAINER_SUBCOMMAND: str = Field(

--- a/nipoppy/config/container.py
+++ b/nipoppy/config/container.py
@@ -116,7 +116,7 @@ class ContainerInfo(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class SchemaWithContainerConfig(BaseModel):
+class _SchemaWithContainerConfig(BaseModel):
     """To be inherited by configs that have a ContainerConfig sub-config."""
 
     CONTAINER_CONFIG: ContainerConfig = Field(

--- a/nipoppy/config/main.py
+++ b/nipoppy/config/main.py
@@ -8,7 +8,7 @@ from typing import Any, Optional
 from pydantic import ConfigDict, Field, model_validator
 from typing_extensions import Self
 
-from nipoppy.config.container import SchemaWithContainerConfig
+from nipoppy.config.container import _SchemaWithContainerConfig
 from nipoppy.config.pipeline import (
     BasePipelineConfig,
     BidsPipelineConfig,
@@ -21,7 +21,7 @@ from nipoppy.tabular.dicom_dir_map import DicomDirMap
 from nipoppy.utils import apply_substitutions_to_json, load_json
 
 
-class Config(SchemaWithContainerConfig):
+class Config(_SchemaWithContainerConfig):
     """Schema for dataset configuration."""
 
     DATASET_NAME: str = Field(description="Name of the dataset")

--- a/nipoppy/config/pipeline.py
+++ b/nipoppy/config/pipeline.py
@@ -9,7 +9,7 @@ from typing import Any, Optional, Union
 from pydantic import ConfigDict, Field, model_validator
 from pydantic_core import to_jsonable_python
 
-from nipoppy.config.container import ContainerInfo, SchemaWithContainerConfig
+from nipoppy.config.container import ContainerInfo, _SchemaWithContainerConfig
 from nipoppy.config.pipeline_step import (
     BasePipelineStepConfig,
     BidsPipelineStepConfig,
@@ -18,7 +18,7 @@ from nipoppy.config.pipeline_step import (
 from nipoppy.utils import apply_substitutions_to_json
 
 
-class BasePipelineConfig(SchemaWithContainerConfig, ABC):
+class BasePipelineConfig(_SchemaWithContainerConfig, ABC):
     """Base schema for processing/BIDS pipeline configuration."""
 
     NAME: str = Field(description="Name of the pipeline")

--- a/nipoppy/config/pipeline_step.py
+++ b/nipoppy/config/pipeline_step.py
@@ -10,7 +10,7 @@ from typing import Any, Optional
 from pydantic import ConfigDict, Field, model_validator
 from pydantic_core import to_jsonable_python
 
-from nipoppy.config.container import SchemaWithContainerConfig
+from nipoppy.config.container import _SchemaWithContainerConfig
 from nipoppy.tabular.doughnut import Doughnut
 from nipoppy.utils import apply_substitutions_to_json
 
@@ -24,7 +24,7 @@ class AnalysisLevelType(str, Enum):
     group = "group"
 
 
-class BasePipelineStepConfig(SchemaWithContainerConfig, ABC):
+class BasePipelineStepConfig(_SchemaWithContainerConfig, ABC):
     """Schema for processing pipeline step configuration."""
 
     NAME: Optional[str] = Field(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,17 +34,17 @@ dynamic = ["version"]
 [project.optional-dependencies]
 dev = ["nipoppy[doc]", "nipoppy[test]", "pre-commit"]
 doc = [
-    "furo>=2024.1.29",
-    "pygments-csv-lexer>=0.1.3",
-    "sphinx>=7.2.6",
-    "sphinx-argparse>=0.4.0, !=0.5.0",
-    "sphinx-autoapi==3.0.0",
-    "sphinx-copybutton>=0.5.2",
-    "sphinx-github-changelog>=1.4.0",
-    "sphinx-jsonschema>=1.19.1",
-    "sphinx-togglebutton>=0.3.2",
-    "mdit-py-plugins>=0.4.0",
-    "myst-parser>=2.0.0",
+    "furo",
+    "pygments-csv-lexer",
+    "sphinx",
+    "sphinx-argparse!=0.5.0",
+    "sphinx-autoapi",
+    "sphinx-copybutton",
+    "sphinx-github-changelog",
+    "sphinx-jsonschema",
+    "sphinx-togglebutton",
+    "mdit-py-plugins",
+    "myst-parser",
 ]
 test = [
     "packaging",

--- a/tests/test_config_container.py
+++ b/tests/test_config_container.py
@@ -9,7 +9,7 @@ from pydantic import ValidationError
 from nipoppy.config.container import (
     ContainerConfig,
     ContainerInfo,
-    SchemaWithContainerConfig,
+    _SchemaWithContainerConfig,
     add_bind_path_to_args,
     check_container_args,
     check_container_command,
@@ -140,7 +140,7 @@ def test_container_info_no_extra_fields():
 
 
 def test_schema_with_container_config():
-    class ClassWithContainerConfig(SchemaWithContainerConfig):
+    class ClassWithContainerConfig(_SchemaWithContainerConfig):
         pass
 
     assert isinstance(


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #364

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Relax version restrictions for the `doc` dependencies
- Update jinja templates to be compatible with latest version of `sphinx-autoapi`
  - Also fix redundant class doc sections
- Silence cross-referencing warning
  - Required making the `SchemaWithContainerConfig` class private, which I think makes sense anyway. We should probably make more parts of the API private to make the docs less cluttered...

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- ~Tests have been added~

For bug fixes:
- ~There is at least one test that would fail under the original bug conditions~
