### PR TITLE
[BUG] Do not pool BIDS and PROC pipelines together when searching pipeline configs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -178,11 +178,6 @@ nitpick_ignore = [
     ("py:class", "StrOrPathLike"),
     ("py:class", "nipoppy.env.StrOrPathLike"),
     ("py:class", "typing_extensions.Self"),
-    ("py:obj", "BasePipelineConfig"),
-    ("py:obj", "BasePipelineStepConfig"),
-    ("py:obj", "ContainerConfig"),
-    ("py:obj", "PathInfo"),
-    ("py:obj", "FpathInfo"),
 ]
 
 # -- Sphinx Github Changelog configuration ------------------------------------

--- a/nipoppy/config/main.py
+++ b/nipoppy/config/main.py
@@ -29,7 +29,7 @@ def get_pipeline_version(
     ----------
     pipeline_name : str
         Name of the pipeline, as specified in the config
-    pipeline_configs : list[BasePipelineConfig]
+    pipeline_configs : list[nipoppy.config.pipeline.BasePipelineConfig]
         List of pipeline configurations
 
     Returns

--- a/nipoppy/config/main.py
+++ b/nipoppy/config/main.py
@@ -50,6 +50,29 @@ def get_pipeline_version(
     )
 
 
+def get_pipeline_config(
+    pipeline_name: str,
+    pipeline_version: str,
+    pipeline_configs: list[BasePipelineConfig],
+) -> BasePipelineConfig:
+    """Get the config for a pipeline."""
+    available_pipelines = []
+    for pipeline_config in pipeline_configs:
+        if (
+            pipeline_config.NAME == pipeline_name
+            and pipeline_config.VERSION == pipeline_version
+        ):
+            return pipeline_config
+        available_pipelines.append((pipeline_config.NAME, pipeline_config.VERSION))
+
+    raise ValueError(
+        "No config found for pipeline with "
+        f"NAME={pipeline_name}, VERSION={pipeline_version}"
+        ". Available pipelines and versions: "
+        + ", ".join(f"{name} {version}" for name, version in available_pipelines)
+    )
+
+
 class Config(_SchemaWithContainerConfig):
     """Schema for dataset configuration."""
 
@@ -183,26 +206,6 @@ class Config(_SchemaWithContainerConfig):
         self._check_no_duplicate_pipeline()
 
         return self
-
-    def get_pipeline_config(
-        self,
-        pipeline_name: str,
-        pipeline_version: str,
-    ) -> BasePipelineConfig:
-        """Get the config for a pipeline."""
-        # pooling them together since there should not be any duplicates
-        for pipeline_config in self.PROC_PIPELINES + self.BIDS_PIPELINES:
-            if (
-                pipeline_config.NAME == pipeline_name
-                and pipeline_config.VERSION == pipeline_version
-            ):
-                return pipeline_config
-
-        raise ValueError(
-            "No config found for pipeline with "
-            f"NAME={pipeline_name}, "
-            f"VERSION={pipeline_version}"
-        )
 
     def save(self, fpath: StrOrPathLike, **kwargs):
         """Save the config to a JSON file.

--- a/nipoppy/config/main.py
+++ b/nipoppy/config/main.py
@@ -20,6 +20,36 @@ from nipoppy.tabular.dicom_dir_map import DicomDirMap
 from nipoppy.utils import apply_substitutions_to_json, load_json
 
 
+def get_pipeline_version(
+    pipeline_name: str, pipeline_configs: list[BasePipelineConfig]
+) -> str:
+    """Get the first version associated with a pipeline.
+
+    Parameters
+    ----------
+    pipeline_name : str
+        Name of the pipeline, as specified in the config
+    pipeline_configs : list[BasePipelineConfig]
+        List of pipeline configurations
+
+    Returns
+    -------
+    str
+        The pipeline version
+    """
+    available_pipelines = []
+    for pipeline_config in pipeline_configs:
+        if pipeline_config.NAME == pipeline_name:
+            return pipeline_config.VERSION
+        available_pipelines.append((pipeline_config.NAME, pipeline_config.VERSION))
+
+    raise ValueError(
+        f"No config found for pipeline with NAME={pipeline_name}"
+        ". Available pipelines: "
+        + ", ".join(f"{name} {version}" for name, version in available_pipelines)
+    )
+
+
 class Config(_SchemaWithContainerConfig):
     """Schema for dataset configuration."""
 
@@ -153,28 +183,6 @@ class Config(_SchemaWithContainerConfig):
         self._check_no_duplicate_pipeline()
 
         return self
-
-    def get_pipeline_version(self, pipeline_name: str) -> str:
-        """Get the first version associated with a pipeline.
-
-        Parameters
-        ----------
-        pipeline_name : str
-            Name of the pipeline, as specified in the config
-
-        Returns
-        -------
-        str
-            The pipeline version
-        """
-        # assume there are no duplicates
-        # technically BIDS_PIPELINES and PROC_PIPELINES can share a pipeline name
-        # and have different versions, but this is unlikely (and probably a mistake)
-        for pipeline_config in self.PROC_PIPELINES + self.BIDS_PIPELINES:
-            if pipeline_config.NAME == pipeline_name:
-                return pipeline_config.VERSION
-
-        raise ValueError(f"No config found for pipeline with NAME={pipeline_name}")
 
     def get_pipeline_config(
         self,

--- a/nipoppy/workflows/bids_conversion.py
+++ b/nipoppy/workflows/bids_conversion.py
@@ -50,12 +50,13 @@ class BidsConversionRunner(PipelineRunner):
         return []
 
     @cached_property
+    def _pipeline_configs(self) -> list[BidsPipelineConfig]:
+        return self.config.BIDS_PIPELINES
+
+    @cached_property
     def pipeline_config(self) -> BidsPipelineConfig:
         """Get the user config for the BIDS conversion pipeline."""
-        return self.config.get_pipeline_config(
-            self.pipeline_name,
-            self.pipeline_version,
-        )
+        return super().pipeline_config
 
     @cached_property
     def pipeline_step_config(self) -> BidsPipelineStepConfig:

--- a/nipoppy/workflows/pipeline.py
+++ b/nipoppy/workflows/pipeline.py
@@ -17,7 +17,7 @@ from nipoppy.config.boutiques import (
     BoutiquesConfig,
     get_boutiques_config_from_descriptor,
 )
-from nipoppy.config.main import get_pipeline_version
+from nipoppy.config.main import get_pipeline_config, get_pipeline_version
 from nipoppy.config.pipeline import ProcPipelineConfig
 from nipoppy.config.pipeline_step import AnalysisLevelType, ProcPipelineStepConfig
 from nipoppy.env import (
@@ -148,8 +148,8 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
     @cached_property
     def pipeline_config(self) -> ProcPipelineConfig:
         """Get the user config for the pipeline."""
-        return self.config.get_pipeline_config(
-            self.pipeline_name, self.pipeline_version
+        return get_pipeline_config(
+            self.pipeline_name, self.pipeline_version, self._pipeline_configs
         )
 
     @cached_property

--- a/nipoppy/workflows/pipeline.py
+++ b/nipoppy/workflows/pipeline.py
@@ -17,6 +17,7 @@ from nipoppy.config.boutiques import (
     BoutiquesConfig,
     get_boutiques_config_from_descriptor,
 )
+from nipoppy.config.main import get_pipeline_version
 from nipoppy.config.pipeline import ProcPipelineConfig
 from nipoppy.config.pipeline_step import AnalysisLevelType, ProcPipelineStepConfig
 from nipoppy.env import (
@@ -139,6 +140,10 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
             participant_id=self.participant_id,
             session_id=self.session_id,
         )
+
+    @cached_property
+    def _pipeline_configs(self) -> list[ProcPipelineConfig]:
+        return self.config.PROC_PIPELINES
 
     @cached_property
     def pipeline_config(self) -> ProcPipelineConfig:
@@ -353,8 +358,9 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
     def check_pipeline_version(self):
         """Set the pipeline version based on the config if it is not given."""
         if self.pipeline_version is None:
-            self.pipeline_version = self.config.get_pipeline_version(
-                pipeline_name=self.pipeline_name
+            self.pipeline_version = get_pipeline_version(
+                pipeline_name=self.pipeline_name,
+                pipeline_configs=self._pipeline_configs,
             )
             self.logger.warning(
                 f"Pipeline version not specified, using version {self.pipeline_version}"

--- a/tests/test_config_main.py
+++ b/tests/test_config_main.py
@@ -8,7 +8,7 @@ import pytest
 from pydantic import ValidationError
 
 from nipoppy.config.container import ContainerConfig
-from nipoppy.config.main import Config, get_pipeline_version
+from nipoppy.config.main import Config, get_pipeline_config, get_pipeline_version
 from nipoppy.config.pipeline import BasePipelineConfig, ProcPipelineConfig
 from nipoppy.utils import FPATH_SAMPLE_CONFIG
 
@@ -209,10 +209,11 @@ def test_propagate_container_config(
         }
     ]
 
+    config = Config(**data).propagate_container_config()
     container_config = (
-        Config(**data)
-        .propagate_container_config()
-        .get_pipeline_config(pipeline_name, pipeline_version)
+        get_pipeline_config(
+            pipeline_name, pipeline_version, getattr(config, pipeline_field)
+        )
         .get_step_config(step_name)
         .get_container_config()
     )
@@ -221,7 +222,7 @@ def test_propagate_container_config(
 
 
 @pytest.mark.parametrize(
-    "pipeline_name,pipelines_key,expected_version",
+    "pipeline_name,pipeline_field,expected_version",
     [
         ("pipeline1", "PROC_PIPELINES", "v1"),
         ("pipeline2", "PROC_PIPELINES", "1.0"),
@@ -229,49 +230,61 @@ def test_propagate_container_config(
     ],
 )
 def test_get_pipeline_version(
-    valid_config_data, pipeline_name, pipelines_key, expected_version
+    valid_config_data, pipeline_name, pipeline_field, expected_version
 ):
     config = Config(**valid_config_data)
     assert (
-        get_pipeline_version(pipeline_name, getattr(config, pipelines_key))
+        get_pipeline_version(pipeline_name, getattr(config, pipeline_field))
         == expected_version
     )
 
 
 @pytest.mark.parametrize(
-    "pipeline_name,pipelines_key",
+    "pipeline_name,pipeline_field",
     [
         ("pipeline1", "BIDS_PIPELINES"),
         ("not_a_pipeline", "PROC_PIPELINES"),
     ],
 )
 def test_get_pipeline_version_invalid_name(
-    valid_config_data, pipeline_name, pipelines_key
+    valid_config_data, pipeline_name, pipeline_field
 ):
     config = Config(**valid_config_data)
     with pytest.raises(ValueError, match="No config found for pipeline"):
-        get_pipeline_version(pipeline_name, getattr(config, pipelines_key))
+        get_pipeline_version(pipeline_name, getattr(config, pipeline_field))
 
 
 @pytest.mark.parametrize(
-    "pipeline,version",
+    "pipeline,version,pipeline_field",
     [
-        ("pipeline1", "v1"),
-        ("pipeline2", "2.0"),
-        ("bids_converter", "1.0"),
-        ("bids_converter", "1.0"),
+        ("pipeline1", "v1", "PROC_PIPELINES"),
+        ("pipeline2", "2.0", "PROC_PIPELINES"),
+        ("bids_converter", "1.0", "BIDS_PIPELINES"),
     ],
 )
-def test_get_pipeline_config(pipeline, version, valid_config_data):
+def test_get_pipeline_config(pipeline, version, pipeline_field, valid_config_data):
+    config = Config(**valid_config_data)
     assert isinstance(
-        Config(**valid_config_data).get_pipeline_config(pipeline, version),
+        get_pipeline_config(pipeline, version, getattr(config, pipeline_field)),
         BasePipelineConfig,
     )
 
 
-def test_get_pipeline_config_missing(valid_config_data):
+@pytest.mark.parametrize(
+    "pipeline,version,pipeline_field",
+    [
+        ("not_a_pipeline", "v1", "PROC_PIPELINES"),
+        ("pipeline2", "not_a_version", "PROC_PIPELINES"),
+        ("pipeline2", "2.0", "BIDS_PIPELINES"),
+        ("bids_converter", "1.0", "PROC_PIPELINES"),
+    ],
+)
+def test_get_pipeline_config_missing(
+    pipeline, version, pipeline_field, valid_config_data
+):
+    config = Config(**valid_config_data)
     with pytest.raises(ValueError):
-        Config(**valid_config_data).get_pipeline_config("not_a_pipeline", "v1")
+        get_pipeline_config(pipeline, version, getattr(config, pipeline_field))
 
 
 def test_save(tmp_path: Path, valid_config_data):

--- a/tests/test_workflow_bids_conversion.py
+++ b/tests/test_workflow_bids_conversion.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from nipoppy.config.main import Config
+from nipoppy.config.pipeline import BidsPipelineConfig
 from nipoppy.tabular.doughnut import Doughnut
 from nipoppy.workflows.bids_conversion import BidsConversionRunner
 
@@ -33,6 +34,45 @@ def config() -> Config:
             },
         ]
     )
+
+
+@pytest.mark.parametrize(
+    "pipeline_name,expected_version",
+    [
+        ("heudiconv", "0.12.2"),
+        ("dcm2bids", "3.1.0"),
+    ],
+)
+def test_check_pipeline_version(
+    pipeline_name, expected_version, config: Config, tmp_path: Path
+):
+    workflow = BidsConversionRunner(
+        dpath_root=tmp_path,
+        pipeline_name=pipeline_name,
+        pipeline_version=None,
+    )
+    config.save(workflow.layout.fpath_config)
+    workflow.check_pipeline_version()
+    assert workflow.pipeline_version == expected_version
+
+
+@pytest.mark.parametrize(
+    "pipeline_name,pipeline_version",
+    [
+        ("heudiconv", "0.12.2"),
+        ("dcm2bids", "3.1.0"),
+    ],
+)
+def test_pipeline_config(
+    pipeline_name, pipeline_version, config: Config, tmp_path: Path
+):
+    workflow = BidsConversionRunner(
+        dpath_root=tmp_path,
+        pipeline_name=pipeline_name,
+        pipeline_version=pipeline_version,
+    )
+    config.save(workflow.layout.fpath_config)
+    assert isinstance(workflow.pipeline_config, BidsPipelineConfig)
 
 
 def test_setup(config: Config, tmp_path: Path):

--- a/tests/test_workflow_bids_conversion.py
+++ b/tests/test_workflow_bids_conversion.py
@@ -108,8 +108,6 @@ def test_cleanup_no_doughnut_update(config: Config, tmp_path: Path):
     workflow.doughnut = Doughnut()
     config.save(workflow.layout.fpath_config)
 
-    print(config.get_pipeline_config("heudiconv", "0.12.2"))
-
     workflow.run_cleanup()
 
     assert not workflow.layout.fpath_doughnut.exists()

--- a/tests/test_workflow_pipeline.py
+++ b/tests/test_workflow_pipeline.py
@@ -518,7 +518,7 @@ def test_set_up_bids_db_ignore_patterns(workflow: PipelineWorkflow, tmp_path: Pa
 
 @pytest.mark.parametrize(
     "pipeline_name,expected_version",
-    [("heudiconv", "0.12.2"), ("fmriprep", "23.1.3"), ("my_pipeline", "1.0")],
+    [("fmriprep", "23.1.3"), ("my_pipeline", "1.0")],
 )
 def test_check_pipeline_version(
     pipeline_name,

--- a/tests/test_workflow_pipeline.py
+++ b/tests/test_workflow_pipeline.py
@@ -73,14 +73,6 @@ def workflow(tmp_path: Path):
     # write config
     config = get_config(
         visit_ids=["1"],
-        bids_pipelines=[
-            # built-in pipelines
-            {
-                "NAME": "heudiconv",
-                "VERSION": "0.12.2",
-                "STEPS": [{"NAME": "prepare"}, {"NAME": "convert"}],
-            }
-        ],
         proc_pipelines=[
             # built-in pipelines
             {
@@ -216,7 +208,6 @@ def test_fpath_container_not_found(workflow: PipelineWorkflow):
     "pipeline_name,pipeline_version,pipeline_step,descriptor",
     [
         ("fmriprep", "23.1.3", None, {}),
-        ("heudiconv", "0.12.2", "prepare", {"key1": "value1"}),
         ("my_pipeline", "1.0", None, {"key2": "value2"}),
     ],
 )
@@ -537,7 +528,6 @@ def test_check_pipeline_version(
 @pytest.mark.parametrize(
     "pipeline_name,pipeline_version,expected_step",
     [
-        ("heudiconv", "0.12.2", "prepare"),
         ("fmriprep", "23.1.3", None),
         ("my_pipeline", "1.0", None),
     ],


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #388
- Needed for eventual PR for #385

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Make `get_pipeline_version` and `get_pipeline_config` in `nipoppy.config.main` take a list of pipelines as input
  - Previously they were hardcoded to pool together the config's `BIDS_PIPELINES` and `PROC_PIPELINES`
- Add a `_pipeline_configs` attribute to `BasePipelineWorkflow` which will be used by `check_pipeline_version` and the `pipeline_config` property

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions
