### PR TITLE
[FIX] Do not enable markup language processing when logging messages related to subprocesses

### DIFF
--- a/nipoppy/workflows/base.py
+++ b/nipoppy/workflows/base.py
@@ -124,10 +124,8 @@ class BaseWorkflow(Base, ABC):
         subprocess.Popen or str
         """
 
-        def process_output(
-            output_source, output_str: str, log_prefix: str, log_level=logging.INFO
-        ):
-            """Consume lines from an IO stream and append them to a string."""
+        def process_output(output_source, log_prefix: str, log_level=logging.INFO):
+            """Consume lines from an IO stream and log them."""
             for line in output_source:
                 line = line.strip("\n")
                 # using extra={"markup": False} in case the output contains substrings
@@ -137,7 +135,6 @@ class BaseWorkflow(Base, ABC):
                     msg=f"{log_prefix} {line}",
                     extra={"markup": False},
                 )
-            return output_str
 
         # build command string
         if not isinstance(command_or_args, str):
@@ -153,8 +150,6 @@ class BaseWorkflow(Base, ABC):
 
         self.log_command(command)
 
-        stdout_str = ""
-        stderr_str = ""
         if not self.dry_run:
             process = subprocess.Popen(
                 command_or_args,
@@ -165,15 +160,13 @@ class BaseWorkflow(Base, ABC):
             )
 
             while process.poll() is None:
-                stdout_str = process_output(
+                process_output(
                     process.stdout,
-                    stdout_str,
                     self.log_prefix_run_stdout,
                 )
 
-                stderr_str = process_output(
+                process_output(
                     process.stderr,
-                    stderr_str,
                     self.log_prefix_run_stderr,
                     log_level=logging.ERROR,
                 )

--- a/nipoppy/workflows/base.py
+++ b/nipoppy/workflows/base.py
@@ -90,7 +90,7 @@ class BaseWorkflow(Base, ABC):
 
     def log_command(self, command: str):
         """Write a command to the log with a special prefix."""
-        self.logger.info(f"{self.log_prefix_run} {command}")
+        self.logger.info(f"{self.log_prefix_run} {command}", extra={"markup": False})
 
     def run_command(
         self,
@@ -128,7 +128,11 @@ class BaseWorkflow(Base, ABC):
             """Consume lines from an IO stream and append them to a string."""
             for line in output_source:
                 line = line.strip("\n")
-                self.logger.log(level=log_level, msg=f"{log_prefix} {line}")
+                self.logger.log(
+                    level=log_level,
+                    msg=f"{log_prefix} {line}",
+                    extra={"markup": False},
+                )
             return output_str
 
         # build command string

--- a/nipoppy/workflows/base.py
+++ b/nipoppy/workflows/base.py
@@ -90,6 +90,8 @@ class BaseWorkflow(Base, ABC):
 
     def log_command(self, command: str):
         """Write a command to the log with a special prefix."""
+        # using extra={"markup": False} in case the command contains substrings
+        # that would be interpreted as closing tags by the RichHandler
         self.logger.info(f"{self.log_prefix_run} {command}", extra={"markup": False})
 
     def run_command(
@@ -128,6 +130,8 @@ class BaseWorkflow(Base, ABC):
             """Consume lines from an IO stream and append them to a string."""
             for line in output_source:
                 line = line.strip("\n")
+                # using extra={"markup": False} in case the output contains substrings
+                # that would be interpreted as closing tags by the RichHandler
                 self.logger.log(
                     level=log_level,
                     msg=f"{log_prefix} {line}",

--- a/tests/test_workflow_base.py
+++ b/tests/test_workflow_base.py
@@ -79,6 +79,17 @@ def test_log_command(
     assert command in record.message
 
 
+def test_log_command_no_markup(
+    workflow: BaseWorkflow, caplog: pytest.LogCaptureFixture
+):
+    # message with closing tag
+    message = "[/]"
+
+    # this should not raise a rich markup error
+    workflow.run_command(["echo", message])
+    assert message in caplog.text
+
+
 def test_run_command(workflow: BaseWorkflow, tmp_path: Path):
     fpath = tmp_path / "test.txt"
     process = workflow.run_command(["touch", fpath])
@@ -104,6 +115,19 @@ def test_run_command_dry_run(workflow: BaseWorkflow, tmp_path: Path):
 def test_run_command_check(workflow: BaseWorkflow):
     with pytest.raises(subprocess.CalledProcessError):
         workflow.run_command(["which", "probably_fake_command"], check=True)
+
+
+def test_run_command_no_markup(
+    workflow: BaseWorkflow, caplog: pytest.LogCaptureFixture, tmp_path: Path
+):
+    # text with closing tag
+    text = "[/]"
+
+    # this should not raise a rich markup error
+    fpath_txt = tmp_path / "test.txt"
+    fpath_txt.write_text(text)
+    workflow.run_command(["cat", fpath_txt])
+    assert text in caplog.text
 
 
 def test_run_setup(workflow: BaseWorkflow, caplog: pytest.LogCaptureFixture):


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #409

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Add `extra={'markup': False}` to `BaseWorkflow.run_command` and `BaseWorkflow.log_command` logger calls

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- ~Tests have been added~

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions
