### PR TITLE
[ENH] Allow BIDS datasets without session level

### DIFF
--- a/nipoppy/env.py
+++ b/nipoppy/env.py
@@ -9,7 +9,7 @@ StrOrPathLike = TypeVar("StrOrPathLike", str, os.PathLike)
 # BIDS
 BIDS_SUBJECT_PREFIX = "sub-"
 BIDS_SESSION_PREFIX = "ses-"
-FAKE_SESSION_ID = "IsFake"
+FAKE_SESSION_ID = "unnamed"
 
 # default config
 DEFAULT_PIPELINE_STEP_NAME = "default"

--- a/nipoppy/env.py
+++ b/nipoppy/env.py
@@ -9,7 +9,7 @@ StrOrPathLike = TypeVar("StrOrPathLike", str, os.PathLike)
 # BIDS
 BIDS_SUBJECT_PREFIX = "sub-"
 BIDS_SESSION_PREFIX = "ses-"
-FAKE_SESSION = "ses-IsFake"
+FAKE_SESSION_ID = "IsFake"
 
 # default config
 DEFAULT_PIPELINE_STEP_NAME = "default"

--- a/nipoppy/env.py
+++ b/nipoppy/env.py
@@ -9,6 +9,7 @@ StrOrPathLike = TypeVar("StrOrPathLike", str, os.PathLike)
 # BIDS
 BIDS_SUBJECT_PREFIX = "sub-"
 BIDS_SESSION_PREFIX = "ses-"
+FAKE_SESSION = "ses-IsFake"
 
 # default config
 DEFAULT_PIPELINE_STEP_NAME = "default"

--- a/nipoppy/tabular/doughnut.py
+++ b/nipoppy/tabular/doughnut.py
@@ -9,7 +9,7 @@ from typing import Optional
 from pydantic import Field
 from typing_extensions import Self
 
-from nipoppy.env import StrOrPathLike, FAKE_SESSION
+from nipoppy.env import FAKE_SESSION, StrOrPathLike
 from nipoppy.logger import get_logger
 from nipoppy.tabular.dicom_dir_map import DicomDirMap
 from nipoppy.tabular.manifest import Manifest, ManifestModel

--- a/nipoppy/tabular/doughnut.py
+++ b/nipoppy/tabular/doughnut.py
@@ -9,7 +9,7 @@ from typing import Optional
 from pydantic import Field
 from typing_extensions import Self
 
-from nipoppy.env import FAKE_SESSION, StrOrPathLike
+from nipoppy.env import FAKE_SESSION_ID, StrOrPathLike
 from nipoppy.logger import get_logger
 from nipoppy.tabular.dicom_dir_map import DicomDirMap
 from nipoppy.tabular.manifest import Manifest, ManifestModel
@@ -206,18 +206,16 @@ def generate_doughnut(
                 dpath=dpath_organized,
                 dname_subdirectory=Path(bids_participant_id, bids_session_id),
             )
-            if session_id == FAKE_SESSION:
+            if session_id == FAKE_SESSION_ID:
                 # if the session is fake, we don't expect BIDS data
                 # to have bids_session_id in the path
-                status_bidsified = check_status(
-                    dpath=dpath_bidsified,
-                    dname_subdirectory=Path(bids_participant_id),
-                )
+                dname_subdirectory = Path(bids_participant_id)
             else:
-                status_bidsified = check_status(
-                    dpath=dpath_bidsified,
-                    dname_subdirectory=Path(bids_participant_id, bids_session_id),
-                )
+                dname_subdirectory = Path(bids_participant_id, bids_session_id)
+            status_bidsified = check_status(
+                dpath=dpath_bidsified,
+                dname_subdirectory=dname_subdirectory,
+            )
 
         doughnut_records.append(
             {

--- a/nipoppy/tabular/doughnut.py
+++ b/nipoppy/tabular/doughnut.py
@@ -9,7 +9,7 @@ from typing import Optional
 from pydantic import Field
 from typing_extensions import Self
 
-from nipoppy.env import StrOrPathLike
+from nipoppy.env import StrOrPathLike, FAKE_SESSION
 from nipoppy.logger import get_logger
 from nipoppy.tabular.dicom_dir_map import DicomDirMap
 from nipoppy.tabular.manifest import Manifest, ManifestModel
@@ -206,10 +206,18 @@ def generate_doughnut(
                 dpath=dpath_organized,
                 dname_subdirectory=Path(bids_participant_id, bids_session_id),
             )
-            status_bidsified = check_status(
-                dpath=dpath_bidsified,
-                dname_subdirectory=Path(bids_participant_id, bids_session_id),
-            )
+            if session_id == FAKE_SESSION:
+                # if the session is fake, we don't expect BIDS data
+                # to have bids_session_id in the path
+                status_bidsified = check_status(
+                    dpath=dpath_bidsified,
+                    dname_subdirectory=Path(bids_participant_id),
+                )
+            else:
+                status_bidsified = check_status(
+                    dpath=dpath_bidsified,
+                    dname_subdirectory=Path(bids_participant_id, bids_session_id),
+                )
 
         doughnut_records.append(
             {

--- a/nipoppy/workflows/dataset_init.py
+++ b/nipoppy/workflows/dataset_init.py
@@ -170,7 +170,9 @@ class InitWorkflow(BaseWorkflow):
                     datatypes = sorted(
                         [
                             x.name
-                            for x in (self.layout.dpath_bids / bids_participant_id).iterdir()
+                            for x in (
+                                self.layout.dpath_bids / bids_participant_id
+                            ).iterdir()
                             if x.is_dir()
                         ]
                     )
@@ -178,7 +180,11 @@ class InitWorkflow(BaseWorkflow):
                     datatypes = sorted(
                         [
                             x.name
-                            for x in (self.layout.dpath_bids / bids_participant_id / bids_session_id).iterdir()
+                            for x in (
+                                self.layout.dpath_bids
+                                / bids_participant_id
+                                / bids_session_id
+                            ).iterdir()
                             if x.is_dir()
                         ]
                     )
@@ -190,7 +196,9 @@ class InitWorkflow(BaseWorkflow):
                     )
                     continue
 
-                df[Manifest.col_participant_id].append(check_participant_id(bids_participant_id))
+                df[Manifest.col_participant_id].append(
+                    check_participant_id(bids_participant_id)
+                )
                 df[Manifest.col_session_id].append(check_session_id(bids_session_id))
                 df[Manifest.col_datatype].append(datatypes)
 

--- a/nipoppy/workflows/dataset_init.py
+++ b/nipoppy/workflows/dataset_init.py
@@ -159,7 +159,8 @@ class InitWorkflow(BaseWorkflow):
                 # if there are no session folders
                 # we will add a fake session for this participant
                 self.logger.warning(
-                    f"Could not find session-level folder(s) for participant {bids_participant_id}, using {FAKE_SESSION_ID} in the manifest"
+                    f"Could not find session-level folder(s) for "
+                    f"participant {bids_participant_id}, using {FAKE_SESSION_ID} in the manifest"
                 )
                 bids_session_ids = [f"{BIDS_SESSION_PREFIX}{FAKE_SESSION_ID}"]
 
@@ -192,7 +193,8 @@ class InitWorkflow(BaseWorkflow):
                 # if there are no datatypes, raise warning and skip
                 if len(datatypes) == 0:
                     self.logger.warning(
-                        f"Participant {bids_participant_id}, session {bids_session_id} has no datatypes. Skipping."
+                        f"Participant {bids_participant_id},"
+                        f" session {bids_session_id} has no datatypes. Skipping."
                     )
                     continue
 

--- a/nipoppy/workflows/dataset_init.py
+++ b/nipoppy/workflows/dataset_init.py
@@ -159,7 +159,7 @@ class InitWorkflow(BaseWorkflow):
                 # if there are no session folders
                 # we will add a fake session for this participant
                 self.logger.warning(
-                    f"Could not find session-level folder(s) for participant "
+                    "Could not find session-level folder(s) for participant "
                     f"{bids_participant_id}, using {FAKE_SESSION_ID} in the manifest"
                 )
                 bids_session_ids = [f"{BIDS_SESSION_PREFIX}{FAKE_SESSION_ID}"]
@@ -189,14 +189,6 @@ class InitWorkflow(BaseWorkflow):
                             if x.is_dir()
                         ]
                     )
-
-                # if there are no datatypes, raise warning and skip
-                if len(datatypes) == 0:
-                    self.logger.warning(
-                        f"Participant {bids_participant_id},"
-                        f" session {bids_session_id} has no datatypes. Skipping."
-                    )
-                    continue
 
                 df[Manifest.col_participant_id].append(
                     check_participant_id(bids_participant_id)

--- a/nipoppy/workflows/dataset_init.py
+++ b/nipoppy/workflows/dataset_init.py
@@ -164,9 +164,7 @@ class InitWorkflow(BaseWorkflow):
                     f"{bids_participant_id}, using session {FAKE_SESSION_ID} "
                     "in the manifest"
                 )
-                bids_session_ids = [
-                    f"{session_id_to_bids_session_id(FAKE_SESSION_ID)}"
-                ]
+                bids_session_ids = [f"{session_id_to_bids_session_id(FAKE_SESSION_ID)}"]
 
             for bids_session_id in bids_session_ids:
                 if (

--- a/nipoppy/workflows/dataset_init.py
+++ b/nipoppy/workflows/dataset_init.py
@@ -159,8 +159,8 @@ class InitWorkflow(BaseWorkflow):
                 # if there are no session folders
                 # we will add a fake session for this participant
                 self.logger.warning(
-                    f"Could not find session-level folder(s) for "
-                    f"participant {bids_participant_id}, using {FAKE_SESSION_ID} in the manifest"
+                    f"Could not find session-level folder(s) for participant "
+                    f"{bids_participant_id}, using {FAKE_SESSION_ID} in the manifest"
                 )
                 bids_session_ids = [f"{BIDS_SESSION_PREFIX}{FAKE_SESSION_ID}"]
 

--- a/nipoppy/workflows/dataset_init.py
+++ b/nipoppy/workflows/dataset_init.py
@@ -20,7 +20,7 @@ from nipoppy.utils import (
     FPATH_SAMPLE_MANIFEST,
     check_participant_id,
     check_session_id,
-    participant_id_to_bids_participant_id,
+    session_id_to_bids_session_id,
 )
 from nipoppy.workflows.base import BaseWorkflow
 
@@ -161,12 +161,18 @@ class InitWorkflow(BaseWorkflow):
                 # we will add a fake session for this participant
                 self.logger.warning(
                     "Could not find session-level folder(s) for participant "
-                    f"{bids_participant_id}, using session {FAKE_SESSION_ID} in the manifest"
+                    f"{bids_participant_id}, using session {FAKE_SESSION_ID} "
+                    "in the manifest"
                 )
-                bids_session_ids = [f"{participant_id_to_bids_participant_id(FAKE_SESSION_ID)}"]
+                bids_session_ids = [
+                    f"{session_id_to_bids_session_id(FAKE_SESSION_ID)}"
+                ]
 
             for bids_session_id in bids_session_ids:
-                if bids_session_id == f"{participant_id_to_bids_participant_id(FAKE_SESSION_ID)}":
+                if (
+                    bids_session_id
+                    == f"{session_id_to_bids_session_id(FAKE_SESSION_ID)}"
+                ):
                     # if the session is fake, we don't expect BIDS data
                     # to have session dir in the path
                     datatypes = sorted(

--- a/nipoppy/workflows/dataset_init.py
+++ b/nipoppy/workflows/dataset_init.py
@@ -20,6 +20,7 @@ from nipoppy.utils import (
     FPATH_SAMPLE_MANIFEST,
     check_participant_id,
     check_session_id,
+    participant_id_to_bids_participant_id,
 )
 from nipoppy.workflows.base import BaseWorkflow
 
@@ -160,12 +161,12 @@ class InitWorkflow(BaseWorkflow):
                 # we will add a fake session for this participant
                 self.logger.warning(
                     "Could not find session-level folder(s) for participant "
-                    f"{bids_participant_id}, using {FAKE_SESSION_ID} in the manifest"
+                    f"{bids_participant_id}, using session {FAKE_SESSION_ID} in the manifest"
                 )
-                bids_session_ids = [f"{BIDS_SESSION_PREFIX}{FAKE_SESSION_ID}"]
+                bids_session_ids = [f"{participant_id_to_bids_participant_id(FAKE_SESSION_ID)}"]
 
             for bids_session_id in bids_session_ids:
-                if bids_session_id == f"{BIDS_SESSION_PREFIX}{FAKE_SESSION_ID}":
+                if bids_session_id == f"{participant_id_to_bids_participant_id(FAKE_SESSION_ID)}":
                     # if the session is fake, we don't expect BIDS data
                     # to have session dir in the path
                     datatypes = sorted(

--- a/nipoppy/workflows/pipeline.py
+++ b/nipoppy/workflows/pipeline.py
@@ -23,7 +23,7 @@ from nipoppy.config.pipeline_step import AnalysisLevelType, ProcPipelineStepConf
 from nipoppy.env import (
     BIDS_SESSION_PREFIX,
     BIDS_SUBJECT_PREFIX,
-    FAKE_SESSION,
+    FAKE_SESSION_ID,
     LogColor,
     ReturnCode,
     StrOrPathLike,
@@ -316,7 +316,7 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
                 current=pybids_ignore_patterns,
                 new=f"^(?!/{BIDS_SUBJECT_PREFIX}({participant_id}))",
             )
-        if (session_id is not None) and (session_id != FAKE_SESSION):
+        if (session_id is not None) and (session_id != FAKE_SESSION_ID):
             add_pybids_ignore_patterns(
                 current=pybids_ignore_patterns,
                 new=f".*?/{BIDS_SESSION_PREFIX}(?!{session_id})",

--- a/nipoppy/workflows/pipeline.py
+++ b/nipoppy/workflows/pipeline.py
@@ -23,6 +23,7 @@ from nipoppy.config.pipeline_step import AnalysisLevelType, ProcPipelineStepConf
 from nipoppy.env import (
     BIDS_SESSION_PREFIX,
     BIDS_SUBJECT_PREFIX,
+    FAKE_SESSION,
     LogColor,
     ReturnCode,
     StrOrPathLike,
@@ -315,7 +316,7 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
                 current=pybids_ignore_patterns,
                 new=f"^(?!/{BIDS_SUBJECT_PREFIX}({participant_id}))",
             )
-        if session_id is not None:
+        if (session_id is not None) and (session_id != FAKE_SESSION):
             add_pybids_ignore_patterns(
                 current=pybids_ignore_patterns,
                 new=f".*?/{BIDS_SESSION_PREFIX}(?!{session_id})",

--- a/tests/test_tabular_doughnut.py
+++ b/tests/test_tabular_doughnut.py
@@ -4,10 +4,12 @@ from contextlib import nullcontext
 from pathlib import Path
 
 import pytest
+from fids import fids
 
-from nipoppy.env import StrOrPathLike
+from nipoppy.env import FAKE_SESSION_ID, StrOrPathLike
 from nipoppy.tabular.dicom_dir_map import DicomDirMap
 from nipoppy.tabular.doughnut import Doughnut, generate_doughnut, update_doughnut
+from nipoppy.workflows.dataset_init import InitWorkflow
 
 from .conftest import DPATH_TEST_DATA, check_doughnut, prepare_dataset
 
@@ -294,4 +296,48 @@ def test_generate_missing_paths(tmp_path: Path):
 
     assert doughnut[Doughnut.col_in_pre_reorg].all()
     assert (~doughnut[Doughnut.col_in_post_reorg]).all()
+    assert doughnut[Doughnut.col_in_bids].all()
+
+
+def test_doughnut_generation_no_session(
+    tmp_path: Path,
+):
+    """Test doughnut generation when there are no session folders.
+
+    Check that the subjects are included and bids valid in the doughnut.
+    """
+    participants_and_sessions_manifest = {
+        "01": [FAKE_SESSION_ID],
+        "02": [FAKE_SESSION_ID],
+    }
+    participants_and_sessions_bidsified = {
+        "01": [None],
+        "02": [None],
+    }
+
+    dpath_root = tmp_path / "my_dataset"
+    dpath_bidsified = dpath_root / "bids"
+
+    manifest = prepare_dataset(
+        participants_and_sessions_manifest=participants_and_sessions_manifest,
+        participants_and_sessions_downloaded=None,
+        participants_and_sessions_organized=None,
+        participants_and_sessions_bidsified=participants_and_sessions_bidsified,
+        dpath_downloaded=None,
+        dpath_organized=None,
+        dpath_bidsified=dpath_bidsified,
+    )
+
+    doughnut = generate_doughnut(
+        manifest=manifest,
+        dicom_dir_map=DicomDirMap.load_or_generate(
+            manifest=manifest, fpath_dicom_dir_map=None, participant_first=True
+        ),
+        dpath_downloaded=None,
+        dpath_organized=None,
+        dpath_bidsified=dpath_bidsified,
+        empty=False,
+    )
+
+    assert doughnut[Doughnut.col_participant_id].to_list() == ["01", "02"]
     assert doughnut[Doughnut.col_in_bids].all()

--- a/tests/test_tabular_doughnut.py
+++ b/tests/test_tabular_doughnut.py
@@ -4,12 +4,10 @@ from contextlib import nullcontext
 from pathlib import Path
 
 import pytest
-from fids import fids
 
 from nipoppy.env import FAKE_SESSION_ID, StrOrPathLike
 from nipoppy.tabular.dicom_dir_map import DicomDirMap
 from nipoppy.tabular.doughnut import Doughnut, generate_doughnut, update_doughnut
-from nipoppy.workflows.dataset_init import InitWorkflow
 
 from .conftest import DPATH_TEST_DATA, check_doughnut, prepare_dataset
 

--- a/tests/test_workflow_init.py
+++ b/tests/test_workflow_init.py
@@ -137,7 +137,7 @@ def test_init_bids_dry_run(tmp_path):
 
 def test_init_bids_warning_no_session(tmp_path, caplog: pytest.LogCaptureFixture):
     """Create dummy BIDS dataset with no session to use during init.
-    
+
     Make sure:
     - raise a warning if subject has no session.
     - manifest is created with the right content
@@ -153,7 +153,10 @@ def test_init_bids_warning_no_session(tmp_path, caplog: pytest.LogCaptureFixture
     )
     workflow = InitWorkflow(dpath_root=dpath_root, bids_source=bids_to_copy)
     workflow.run()
-    assert f"Could not find session-level folder(s) for participant sub-01, using {FAKE_SESSION_ID} in the manifest" in caplog.text
+    assert (
+        f"Could not find session-level folder(s) for participant sub-01, using {FAKE_SESSION_ID} in the manifest"
+        in caplog.text
+    )
 
     assert isinstance(workflow.manifest, Manifest)
 

--- a/tests/test_workflow_init.py
+++ b/tests/test_workflow_init.py
@@ -154,7 +154,7 @@ def test_init_bids_warning_no_session(tmp_path, caplog: pytest.LogCaptureFixture
     workflow = InitWorkflow(dpath_root=dpath_root, bids_source=bids_to_copy)
     workflow.run()
     assert (
-        f"Could not find session-level folder(s) for participant sub-01, using {FAKE_SESSION_ID} in the manifest"
+        f"Could not find session-level folder(s) for participant sub-01, using session {FAKE_SESSION_ID} in the manifest"
         in caplog.text
     )
 

--- a/tests/test_workflow_init.py
+++ b/tests/test_workflow_init.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 from fids import fids
 
+from nipoppy.env import FAKE_SESSION_ID
 from nipoppy.tabular.manifest import Manifest
 from nipoppy.utils import DPATH_LAYOUTS
 from nipoppy.workflows.dataset_init import InitWorkflow
@@ -135,7 +136,13 @@ def test_init_bids_dry_run(tmp_path):
 
 
 def test_init_bids_warning_no_session(tmp_path, caplog: pytest.LogCaptureFixture):
-    """Raise a warning if subject has no session."""
+    """Create dummy BIDS dataset with no session to use during init.
+    
+    Make sure:
+    - raise a warning if subject has no session.
+    - manifest is created with the right content
+    - all the files are there after init.
+    """
     dpath_root = tmp_path / "nipoppy"
     bids_to_copy = tmp_path / "bids"
     fids.create_fake_bids_dataset(
@@ -146,4 +153,13 @@ def test_init_bids_warning_no_session(tmp_path, caplog: pytest.LogCaptureFixture
     )
     workflow = InitWorkflow(dpath_root=dpath_root, bids_source=bids_to_copy)
     workflow.run()
-    assert "could not find a session level folder" in caplog.text
+    assert f"Could not find session-level folder(s) for participant sub-01, using {FAKE_SESSION_ID} in the manifest" in caplog.text
+
+    assert isinstance(workflow.manifest, Manifest)
+
+    assert workflow.manifest[Manifest.col_participant_id].to_list() == ["01"]
+    assert workflow.manifest[Manifest.col_visit_id].to_list() == [FAKE_SESSION_ID]
+    assert workflow.manifest[Manifest.col_session_id].to_list() == [FAKE_SESSION_ID]
+    assert workflow.manifest[Manifest.col_datatype].to_list() == [
+        ["anat", "func"],
+    ]

--- a/tests/test_workflow_pipeline.py
+++ b/tests/test_workflow_pipeline.py
@@ -521,7 +521,9 @@ def test_set_up_bids_db_no_session(
 ):
     """Create a fake BIDS dataset with no session-level folders.
 
-    Check that the ignore pattern is not added to the BIDS layout.
+    Make sure:
+    - Check that the ignore pattern is not added to the BIDS layout.
+    - Check if files are found in the BIDS layout not ignored.
     """
     dpath_pybids_db = tmp_path / "bids_db"
     participant_id = "01"
@@ -530,16 +532,17 @@ def test_set_up_bids_db_no_session(
     fids.create_fake_bids_dataset(
         output_dir=workflow.layout.dpath_bids,
         subjects=participant_id,
-        sessions=session_id,
+        sessions=None,
     )
 
-    workflow.set_up_bids_db(
+    bids_layout = workflow.set_up_bids_db(
         dpath_pybids_db=dpath_pybids_db,
         participant_id=participant_id,
         session_id=session_id,
     )
 
     assert not (f".*?/{BIDS_SESSION_PREFIX}(?!{session_id})" in caplog.text)
+    assert len(bids_layout.get(extension=".nii.gz")) > 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_workflow_pipeline.py
+++ b/tests/test_workflow_pipeline.py
@@ -13,7 +13,14 @@ from fids import fids
 from nipoppy.config.boutiques import BoutiquesConfig
 from nipoppy.config.pipeline import ProcPipelineConfig
 from nipoppy.config.pipeline_step import AnalysisLevelType, ProcPipelineStepConfig
-from nipoppy.env import DEFAULT_PIPELINE_STEP_NAME, LogColor, ReturnCode, StrOrPathLike, FAKE_SESSION_ID, BIDS_SESSION_PREFIX
+from nipoppy.env import (
+    BIDS_SESSION_PREFIX,
+    DEFAULT_PIPELINE_STEP_NAME,
+    FAKE_SESSION_ID,
+    LogColor,
+    ReturnCode,
+    StrOrPathLike,
+)
 from nipoppy.workflows.pipeline import BasePipelineWorkflow, apply_analysis_level
 
 from .conftest import datetime_fixture  # noqa F401

--- a/tests/test_workflow_pipeline.py
+++ b/tests/test_workflow_pipeline.py
@@ -13,7 +13,7 @@ from fids import fids
 from nipoppy.config.boutiques import BoutiquesConfig
 from nipoppy.config.pipeline import ProcPipelineConfig
 from nipoppy.config.pipeline_step import AnalysisLevelType, ProcPipelineStepConfig
-from nipoppy.env import DEFAULT_PIPELINE_STEP_NAME, LogColor, ReturnCode, StrOrPathLike
+from nipoppy.env import DEFAULT_PIPELINE_STEP_NAME, LogColor, ReturnCode, StrOrPathLike, FAKE_SESSION_ID, BIDS_SESSION_PREFIX
 from nipoppy.workflows.pipeline import BasePipelineWorkflow, apply_analysis_level
 
 from .conftest import datetime_fixture  # noqa F401
@@ -505,6 +505,34 @@ def test_set_up_bids_db_ignore_patterns(workflow: PipelineWorkflow, tmp_path: Pa
     )
 
     assert pybids_ignore_patterns == workflow.pybids_ignore_patterns
+
+
+def test_set_up_bids_db_no_session(
+    workflow: PipelineWorkflow,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Create a fake BIDS dataset with no session-level folders.
+
+    Check that the ignore pattern is not added to the BIDS layout.
+    """
+    dpath_pybids_db = tmp_path / "bids_db"
+    participant_id = "01"
+    session_id = FAKE_SESSION_ID
+
+    fids.create_fake_bids_dataset(
+        output_dir=workflow.layout.dpath_bids,
+        subjects=participant_id,
+        sessions=session_id,
+    )
+
+    workflow.set_up_bids_db(
+        dpath_pybids_db=dpath_pybids_db,
+        participant_id=participant_id,
+        session_id=session_id,
+    )
+
+    assert not (f".*?/{BIDS_SESSION_PREFIX}(?!{session_id})" in caplog.text)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #171 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- datasets with no session definition will be allowed
- the manifest file will have a fake session name for participants with no session level when starting from a BIDS dataset
- the doughnut file won't exclude participants with no sessions

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions
