### PR TITLE
[ENH] Rename some input IDs in MRIQC descriptor

### DIFF
--- a/nipoppy/data/examples/sample_pipelines/mriqc-23.1.0/descriptor.json
+++ b/nipoppy/data/examples/sample_pipelines/mriqc-23.1.0/descriptor.json
@@ -3,7 +3,7 @@
     "description": "mriqc",
     "tool-version": "23.1.0",
     "schema-version": "0.5",
-    "command-line": "[[NIPOPPY_CONTAINER_COMMAND]] [[NIPOPPY_FPATH_CONTAINER]] [BIDS_DIR] [OUTPUT_DIR] [ANALYSIS_LEVEL] [VERSION] [VERBOSE_COUNT] [SPECIES] [PARTICIPANT_LABEL] [SESSION_ID] [RUN_ID] [TASK_ID] [MODALITIES] [DSNAME] [BIDS_DATABASE_DIR] [BIDS_DATABASE_WIPE] [NPROCS] [OMP_NTHREADS] [MEMORY_GB] [DEBUG] [FLOAT32] [PDB] [WORK_DIR] [VERBOSE_REPORTS] [REPORTS_ONLY] [WRITE_GRAPH] [DRY_RUN] [RESOURCE_MONITOR] [USE_PLUGIN] [NO_SUB] [EMAIL] [WEBAPI_URL] [WEBAPI_PORT] [UPLOAD_STRICT] [NOTRACK] [ANTS_FLOAT] [ANTS_SETTINGS] [FFT_SPIKES_DETECTOR] [FD_THRES] [DEOBLIQUE] [DESPIKE] [START_IDX] [STOP_IDX]",
+    "command-line": "[[NIPOPPY_CONTAINER_COMMAND]] [[NIPOPPY_FPATH_CONTAINER]] [BIDS_DIR] [OUTPUT_DIR] [ANALYSIS_LEVEL] [VERSION] [VERBOSE_COUNT] [SPECIES] [PARTICIPANT_LABEL] [SESSION_ID] [RUN_ID] [TASK_ID] [MODALITIES] [DSNAME] [BIDS_DATABASE_DIR] [BIDS_DATABASE_WIPE] [NPROCS] [OMP_NTHREADS] [MEM] [DEBUG] [FLOAT32] [PDB] [WORK_DIR] [VERBOSE_REPORTS] [REPORTS_ONLY] [WRITE_GRAPH] [DRY_RUN] [RESOURCE_MONITOR] [USE_PLUGIN] [NO_SUB] [EMAIL] [WEBAPI_URL] [WEBAPI_PORT] [UPLOAD_STRICT] [NOTRACK] [ANTS_FLOAT] [ANTS_SETTINGS] [FFT_SPIKES_DETECTOR] [FD_THRES] [DEOBLIQUE] [DESPIKE] [START_IDX] [STOP_IDX]",
     "inputs": [
         {
             "id": "bids_dir",
@@ -112,7 +112,6 @@
             "description": "Filter input dataset by MRI type.",
             "optional": true,
             "type": "String",
-            "list": true,
             "value-key": "[MODALITIES]",
             "default-value": [
                 "T1w",
@@ -126,7 +125,8 @@
                 "bold",
                 "dwi"
             ],
-            "command-line-flag": "-m"
+            "command-line-flag": "-m",
+            "list": true
         },
         {
             "id": "dsname",
@@ -174,12 +174,12 @@
             "command-line-flag": "--omp-nthreads"
         },
         {
-            "id": "memory_gb",
-            "name": "memory_gb",
+            "id": "mem",
+            "name": "mem",
             "description": "Upper bound memory limit for MRIQC processes.",
             "optional": true,
             "type": "String",
-            "value-key": "[MEMORY_GB]",
+            "value-key": "[MEM]",
             "command-line-flag": "--mem"
         },
         {


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes none
- Related to previous PR fixing fMRIPrep descriptors #426 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Rename some input fields in the descriptor so that they match the MRIQC CLI flags. Otherwise, the Boutiques argparse-to-descriptor function takes the `dest` field by default, which can be misleading if there is a hook function used for the argument's `type` field. For example the `--mem` argument for memory can be specified in non-gigabyte units, but calling the input element `--memory_gb` makes that more obscure

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- ~Tests have been added~

For bug fixes:
- ~There is at least one test that would fail under the original bug conditions~
