### PR TITLE
Make PARTICIPANT_SESSION_DIR field relative to pipeline output directory

### DIFF
--- a/nipoppy/workflows/runner.py
+++ b/nipoppy/workflows/runner.py
@@ -266,14 +266,16 @@ class PipelineRunner(BasePipelineWorkflow):
         )
 
         if self.tar and not self.simulate:
-            dpath_to_tar = TrackerConfig(
+            tracker_config = TrackerConfig(
                 **self.process_template_json(
                     self.tracker_config.model_dump(mode="json"),
                     participant_id=participant_id,
                     session_id=session_id,
                 )
-            ).PARTICIPANT_SESSION_DIR
-            self.tar_directory(dpath_to_tar)
+            )
+            self.tar_directory(
+                self.dpath_pipeline_output / tracker_config.PARTICIPANT_SESSION_DIR
+            )
 
         return to_return
 

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -552,7 +552,7 @@ def test_run_single_tar(
     runner.tracker_config = TrackerConfig(
         PATHS=[tmp_path],  # not used
         PARTICIPANT_SESSION_DIR=(
-            tmp_path / "[[NIPOPPY_PARTICIPANT_ID]]_[[NIPOPPY_BIDS_SESSION_ID]]"
+            "[[NIPOPPY_PARTICIPANT_ID]]_[[NIPOPPY_BIDS_SESSION_ID]]"
         ),
     )
     try:
@@ -563,7 +563,7 @@ def test_run_single_tar(
 
     if tar and boutiques_success:
         mocked_tar_directory.assert_called_once_with(
-            tmp_path / f"{participant_id}_ses-{session_id}"
+            runner.dpath_pipeline_output / f"{participant_id}_ses-{session_id}"
         )
     else:
         mocked_tar_directory.assert_not_called()


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes none

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Previously the tracker config file expected the full path for the directory to be tarred, and the sample configs didn’t work because they were relative. Since the regular tracker paths are relative I think we should be consistent here

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions
