### PR TITLE
[ENH] Improve `DicomReorgWorkflow` customization flexibility and logging

### DIFF
--- a/nipoppy/workflows/dicom_reorg.py
+++ b/nipoppy/workflows/dicom_reorg.py
@@ -82,16 +82,16 @@ class DicomReorgWorkflow(BaseWorkflow):
         return fpaths
 
     def apply_fname_mapping(
-        self, fname_source: str, participant_id: str, session_id: str
+        self, fpath_source: StrOrPathLike, participant_id: str, session_id: str
     ) -> str:
         """
-        Apply a mapping to the file name.
+        Apply a mapping from the original (full) file path to destination file name.
 
         This method does not change the file name by default, but it can be overridden
         if the file names need to be changed during reorganization (e.g. for easier
         BIDS conversion).
         """
-        return fname_source
+        return Path(fpath_source).name
 
     def run_single(self, participant_id: str, session_id: str):
         """Reorganize downloaded DICOM files for a single participant and session."""
@@ -119,9 +119,14 @@ class DicomReorgWorkflow(BaseWorkflow):
                         f"Error checking DICOM file {fpath_source}: {exception}"
                     )
 
-            fpath_dest = dpath_reorganized / self.apply_fname_mapping(
-                fpath_source.name, participant_id=participant_id, session_id=session_id
-            )
+            # the destination path is under dpath_reorganized
+            # resolve the path to avoid issues with symlinks
+            fpath_dest = (
+                dpath_reorganized
+                / self.apply_fname_mapping(
+                    fpath_source, participant_id=participant_id, session_id=session_id
+                )
+            ).resolve()
 
             # do not overwrite existing files
             if fpath_dest.exists():
@@ -131,12 +136,17 @@ class DicomReorgWorkflow(BaseWorkflow):
                 )
 
             # either create symlinks or copy original files
-            if not self.dry_run:
-                if self.copy_files:
-                    self.copy(fpath_source, fpath_dest)
-                else:
-                    fpath_source = os.path.relpath(fpath_source, fpath_dest.parent)
-                    self.create_symlink(path_source=fpath_source, path_dest=fpath_dest)
+            if self.copy_files:
+                self.copy(fpath_source, fpath_dest, log_level=logging.DEBUG)
+            else:
+                fpath_source = os.path.relpath(
+                    fpath_source.resolve(), fpath_dest.parent
+                )
+                self.create_symlink(
+                    path_source=fpath_source,
+                    path_dest=fpath_dest,
+                    log_level=logging.DEBUG,
+                )
 
         # update doughnut entry
         self.doughnut.set_status(

--- a/tests/test_workflow_dicom_reorg.py
+++ b/tests/test_workflow_dicom_reorg.py
@@ -118,20 +118,20 @@ def test_apply_fname_mapping(mapping_func, expected, tmp_path: Path):
 
 
 @pytest.mark.parametrize(
-    "fname_source,expected",
+    "fpath_source,expected",
     [
         ("123456.dcm", "123456.dcm"),
-        (Path("123456.dcm"), Path("123456.dcm")),
-        ("dicoms.tar.gz", "dicoms.tar.gz"),
+        (Path("dirA", "123456.dcm"), "123456.dcm"),
+        ("123/dicoms.tar.gz", "dicoms.tar.gz"),
     ],
 )
-def test_apply_fname_mapping_default(fname_source, expected, tmp_path: Path):
+def test_apply_fname_mapping_default(fpath_source, expected, tmp_path: Path):
     dpath_root = tmp_path / "my_dataset"
     workflow = DicomReorgWorkflow(dpath_root=dpath_root)
 
     assert (
         workflow.apply_fname_mapping(
-            fname_source=fname_source, participant_id="", session_id=""
+            fpath_source=fpath_source, participant_id="", session_id=""
         )
         == expected
     )


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #372 
- Closes #448

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Pass entire filepath (instead of just filename) to `apply_fname_mapping` for more user flexibility
- Resolve source/destination paths to avoid problems with symlinks
- Log symlink/copying operations at `DEBUG` level instead of `INFO`

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- ~Tests have been added~

For bug fixes:
- ~There is at least one test that would fail under the original bug conditions~
