### PR TITLE
[BUG] Fix paths in `fs_stats` extractor default invocation

### DIFF
--- a/nipoppy/data/examples/sample_pipelines/fs_stats-0.2.0/invocation.json
+++ b/nipoppy/data/examples/sample_pipelines/fs_stats-0.2.0/invocation.json
@@ -1,7 +1,7 @@
 {
     "script_path": "[[NIPOPPY_DPATH_PIPELINES]]/fs_stats-0.2.0/script.py",
-    "input_dir_path": "[[NIPOPPY_DPATH_PIPELINE_OUTPUT]]/fs_stats-0.2.0",
-    "output_dir_path": "[[NIPOPPY_DPATH_PIPELINE_IDP]]",
+    "input_dir_path": "[[NIPOPPY_DPATH_PIPELINE_OUTPUT]]",
+    "output_dir_path": "[[NIPOPPY_DPATH_PIPELINE_IDP]]/fs_stats-0.2.0",
     "mode": "multi",
     "with_qc": false,
     "aseg_measures": [


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes none

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Default paths were wrong

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions
