### PR TITLE
[BUG] Fix `nipoppy init` in existing dirs.

### DIFF
--- a/nipoppy/workflows/dataset_init.py
+++ b/nipoppy/workflows/dataset_init.py
@@ -68,11 +68,13 @@ class InitWorkflow(BaseWorkflow):
                 filenames = [
                     f for f in self.dpath_root.iterdir() if f.name != ".DS_STORE"
                 ]
-                if len(filenames) > 0:
-                    raise FileExistsError
-            except (NotADirectoryError, FileExistsError):
+
+            except NotADirectoryError:
+                raise FileExistsError(f"Dataset is an existing file: {self.dpath_root}")
+
+            if len(filenames) > 0:
                 raise FileExistsError(
-                    f"Dataset directory already exists: {self.dpath_root}"
+                    f"Dataset directory is non-empty: {self.dpath_root}"
                 )
 
         # create directories

--- a/nipoppy/workflows/dataset_init.py
+++ b/nipoppy/workflows/dataset_init.py
@@ -64,9 +64,16 @@ class InitWorkflow(BaseWorkflow):
         """
         # dataset must not already exist
         if self.dpath_root.exists():
-            raise FileExistsError(
-                f"Dataset directory already exists: {self.dpath_root}"
-            )
+            try:
+                filenames = [
+                    f for f in self.dpath_root.iterdir() if f.name != ".DS_STORE"
+                ]
+                if len(filenames) > 0:
+                    raise FileExistsError
+            except (NotADirectoryError, FileExistsError):
+                raise FileExistsError(
+                    f"Dataset directory already exists: {self.dpath_root}"
+                )
 
         # create directories
         for dpath in self.layout.dpaths:

--- a/tests/test_workflow_init.py
+++ b/tests/test_workflow_init.py
@@ -18,12 +18,44 @@ def dpath_root(request: pytest.FixtureRequest, tmp_path: Path) -> Path:
     return tmp_path / request.param
 
 
+def exist_or_none(o: object, s: str) -> bool:
+    # walrus operator ":=" does assignment inside the "if" statement
+    if attr := getattr(o, s, None):
+        return attr.exists()
+    return True
+
+
 def test_run(dpath_root: Path):
-    def exist_or_none(o: object, s: str) -> bool:
-        # walrus operator ":=" does assignment inside the "if" statement
-        if attr := getattr(o, s, None):
-            return attr.exists()
-        return True
+    workflow = InitWorkflow(dpath_root=dpath_root)
+    workflow.run()
+
+    # check that all directories have been created
+    for path in ATTR_TO_DPATH_MAP.values():
+        assert Path(dpath_root, path).exists()
+        assert Path(dpath_root, path, "README.md").exists()
+
+    # check that sample config files have been copied
+    assert Path(dpath_root, FPATH_CONFIG).exists()
+    assert Path(dpath_root, FPATH_MANIFEST).exists()
+
+    # check that pipeline config files have been copied
+    for pipeline_configs in (
+        workflow.config.BIDS_PIPELINES,
+        workflow.config.PROC_PIPELINES,
+    ):
+        for pipeline_config in pipeline_configs:
+            assert exist_or_none(pipeline_config, "TRACKER_CONFIG_FILE")
+            for pipeline_step_config in pipeline_config.STEPS:
+                assert exist_or_none(pipeline_step_config, "DESCRIPTOR_FILE")
+                assert exist_or_none(pipeline_step_config, "INVOCATION_FILE")
+                assert exist_or_none(
+                    pipeline_step_config, "PYBIDS_IGNORE_PATTERNS_FILE"
+                )
+
+
+def test_empty_dir(dpath_root: Path):
+    dpath_root.mkdir(parents=True)
+    dpath_root.joinpath(".DS_STORE").touch()  # Allow macOS file
 
     workflow = InitWorkflow(dpath_root=dpath_root)
     workflow.run()
@@ -52,10 +84,20 @@ def test_run(dpath_root: Path):
                 )
 
 
-def test_run_error(dpath_root: Path):
+def test_non_empty_dir(dpath_root: Path):
     dpath_root.mkdir(parents=True)
-    workflow = InitWorkflow(dpath_root=dpath_root)
+    dpath_root.joinpath("unexepected_file").touch()
+
     with pytest.raises(FileExistsError, match="Dataset directory already exists"):
+        workflow = InitWorkflow(dpath_root=dpath_root)
+        workflow.run()
+
+
+def test_is_file(dpath_root: Path):
+    dpath_root.touch()
+
+    with pytest.raises(FileExistsError, match="Dataset directory already exists"):
+        workflow = InitWorkflow(dpath_root=dpath_root)
         workflow.run()
 
 


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #488 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Allow `nipoppy init` in empty dir.  Only `.DS_STORE` can be present.

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions
