### PR TITLE
[MAINT] Use Nipoppy bot instead of PAT for projects automation workflow

### DIFF
--- a/.github/workflows/project_automation.yml
+++ b/.github/workflows/project_automation.yml
@@ -26,11 +26,18 @@ jobs:
     if: github.repository == 'nipoppy/nipoppy'
     steps:
 
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.NIPOPPY_BOT_APP_ID }}
+          private-key: ${{ secrets.NIPOPPY_BOT_PRIVATE_KEY }}
+
       - name: Move issue to ${{ env.triage }}
         if: github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'reopened')
         uses: leonsteinhaeuser/project-beta-automations@v2.2.1
         with:
-          gh_token: ${{ secrets.PROJECT_PAT }}
+          gh_token: ${{ steps.generate-token.outputs.token }}
           organization: ${{ env.organization }}
           project_id: ${{ env.project_id }}
           resource_node_id: ${{ github.event.issue.node_id }}
@@ -40,7 +47,7 @@ jobs:
         if: github.event_name == 'issues' && github.event.action == 'assigned'
         uses: leonsteinhaeuser/project-beta-automations@v2.2.1
         with:
-          gh_token: ${{ secrets.PROJECT_PAT }}
+          gh_token: ${{ steps.generate-token.outputs.token }}
           organization: ${{ env.organization }}
           project_id: ${{ env.project_id }}
           resource_node_id: ${{ github.event.issue.node_id }}
@@ -50,7 +57,7 @@ jobs:
         if: github.event_name == 'pull_request_target' && github.event.action == 'converted_to_draft'
         uses: leonsteinhaeuser/project-beta-automations@v2.2.1
         with:
-          gh_token: ${{ secrets.PROJECT_PAT }}
+          gh_token: ${{ steps.generate-token.outputs.token }}
           organization: ${{ env.organization }}
           project_id: ${{ env.project_id }}
           resource_node_id: ${{ github.event.pull_request.node_id }}
@@ -61,7 +68,7 @@ jobs:
         if: github.event_name == 'pull_request_target' && github.event.pull_request.draft == false && (github.event.action == 'ready_for_review' || github.event.action == 'review_requested')
         uses: leonsteinhaeuser/project-beta-automations@v2.2.1
         with:
-          gh_token: ${{ secrets.PROJECT_PAT }}
+          gh_token: ${{ steps.generate-token.outputs.token }}
           organization: ${{ env.organization }}
           project_id: ${{ env.project_id }}
           resource_node_id: ${{ github.event.pull_request.node_id }}
@@ -71,7 +78,7 @@ jobs:
         if: github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true
         uses: leonsteinhaeuser/project-beta-automations@v2.2.1
         with:
-          gh_token: ${{ secrets.PROJECT_PAT }}
+          gh_token: ${{ steps.generate-token.outputs.token }}
           organization: ${{ env.organization }}
           project_id: ${{ env.project_id }}
           resource_node_id: ${{ github.event.pull_request.node_id }}
@@ -82,7 +89,7 @@ jobs:
         if: github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == false
         uses: leonsteinhaeuser/project-beta-automations@v2.2.1
         with:
-          gh_token: ${{ secrets.PROJECT_PAT }}
+          gh_token: ${{ steps.generate-token.outputs.token }}
           organization: ${{ env.organization }}
           project_id: ${{ env.project_id }}
           resource_node_id: ${{ github.event.pull_request.node_id }}


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #446

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- New GitHub App [`nipoppy-bot`](https://github.com/organizations/nipoppy/settings/installations/61409596) installed in the `nipoppy` org
- New org-level variable `NIPOPPY_BOT_APP_ID` and secret `NIPOPPY_BOT_PRIVATE_KEY`
- Update the `project_automation.yml` workflow to use the bot instead of a PAT

This makes it so that we don't have to keep updating the `PROJECT_PAT` used for GitHub project board automation. However, we will have another PAT for Readthedocs builds (more specifically for auto-generating the changelog), and as far as I can tell we cannot replace that one by a bot because the build happens on Readthedocs servers, not GitHub Actions.

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions
