### PR TITLE
[MAINT] Enable skipping of tests through PR label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,6 @@ updates:
     labels:
       - "T.2 - Maintenance"
       - "bot"
+      - "skip-tests"
     commit-message:
       prefix: "[MAINT] "

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -22,8 +22,8 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
-    # only trigger on upstream repo
-    if: github.repository_owner == 'nipoppy' && github.event.repository.name == 'nipoppy'
+    # only trigger on upstream repo and do not run for PRs with 'skip-tests' label
+    if: github.repository == 'nipoppy/nipoppy' && ! (github.event_name == 'pull_request' && contains(github.event.pull_request.labels, 'skip-tests'))
 
     steps:
 

--- a/.github/workflows/update_citation_cff.yml
+++ b/.github/workflows/update_citation_cff.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   update_version_and_open_pr:
-    if: '!github.event.release.prerelease'
+    if: ! github.event.release.prerelease
     runs-on: ubuntu-latest
 
     steps:
@@ -45,5 +45,5 @@ jobs:
         masterBranchName: main
         title: "[MAINT] Update version in `CITATION.cff` file"
         description: PR opened automatically by [yaml-update-action](https://github.com/fjogeleit/yaml-update-action) GitHub action.
-        labels: "T.2 - Maintenance, bot"
+        labels: "T.2 - Maintenance, bot, skip-tests"
         token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #517

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Do not run tests on Dependabot PRs or `nipoppy-bot` PRs for updating the `CITATION.cff` file (or any PR with the new `skip-tests` label)
- However, PRs created through `pre-commit.ci` cannot have labels, so the tests will still run there

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions
