### PR TITLE
[ENH] Add `bids-validator` `2.0.3`

### DIFF
--- a/nipoppy/data/examples/sample_global_config-all_pipelines.json
+++ b/nipoppy/data/examples/sample_global_config-all_pipelines.json
@@ -134,6 +134,31 @@
     ],
     "PROC_PIPELINES": [
         {
+            "NAME": "bids-validator",
+            "VERSION": "2.0.3",
+            "CONTAINER_INFO": {
+                "FILE": "[[NIPOPPY_DPATH_CONTAINERS]]/deno_2.2.3.sif",
+                "URI": "docker://denoland/deno:2.2.3"
+            },
+            "CONTAINER_CONFIG": {
+                "ENV_VARS": {
+                    "DENO_DIR": "[[NIPOPPY_DPATH_SCRATCH]]/deno"
+                },
+                "ARGS": [
+                    "--bind",
+                    "[[NIPOPPY_DPATH_SCRATCH]]/deno"
+                ]
+            },
+            "STEPS": [
+                {
+                    "INVOCATION_FILE": "[[NIPOPPY_DPATH_PIPELINES]]/[[PIPELINE_NAME]]-[[PIPELINE_VERSION]]/invocation.json",
+                    "DESCRIPTOR_FILE": "[[NIPOPPY_DPATH_PIPELINES]]/[[PIPELINE_NAME]]-[[PIPELINE_VERSION]]/descriptor.json",
+                    "ANALYSIS_LEVEL": "group",
+                    "GENERATE_PYBIDS_DATABASE": false
+                }
+            ]
+        },
+        {
             "NAME": "fmriprep",
             "VERSION": "24.1.1",
             "CONTAINER_INFO": {

--- a/nipoppy/data/examples/sample_global_config-all_pipelines.json
+++ b/nipoppy/data/examples/sample_global_config-all_pipelines.json
@@ -141,12 +141,9 @@
                 "URI": "docker://denoland/deno:2.2.3"
             },
             "CONTAINER_CONFIG": {
-                "ENV_VARS": {
-                    "DENO_DIR": "[[NIPOPPY_DPATH_SCRATCH]]/deno"
-                },
                 "ARGS": [
                     "--bind",
-                    "[[NIPOPPY_DPATH_SCRATCH]]/deno"
+                    "[[NIPOPPY_DPATH_SCRATCH]]/deno:/deno-dir"
                 ]
             },
             "STEPS": [

--- a/nipoppy/data/examples/sample_global_config-latest_pipelines.json
+++ b/nipoppy/data/examples/sample_global_config-latest_pipelines.json
@@ -113,12 +113,9 @@
                 "URI": "docker://denoland/deno:2.2.3"
             },
             "CONTAINER_CONFIG": {
-                "ENV_VARS": {
-                    "DENO_DIR": "[[NIPOPPY_DPATH_SCRATCH]]/deno"
-                },
                 "ARGS": [
                     "--bind",
-                    "[[NIPOPPY_DPATH_SCRATCH]]/deno"
+                    "[[NIPOPPY_DPATH_SCRATCH]]/deno:/deno-dir"
                 ]
             },
             "STEPS": [

--- a/nipoppy/data/examples/sample_global_config-latest_pipelines.json
+++ b/nipoppy/data/examples/sample_global_config-latest_pipelines.json
@@ -106,6 +106,31 @@
     ],
     "PROC_PIPELINES": [
         {
+            "NAME": "bids-validator",
+            "VERSION": "2.0.3",
+            "CONTAINER_INFO": {
+                "FILE": "[[NIPOPPY_DPATH_CONTAINERS]]/deno_2.2.3.sif",
+                "URI": "docker://denoland/deno:2.2.3"
+            },
+            "CONTAINER_CONFIG": {
+                "ENV_VARS": {
+                    "DENO_DIR": "[[NIPOPPY_DPATH_SCRATCH]]/deno"
+                },
+                "ARGS": [
+                    "--bind",
+                    "[[NIPOPPY_DPATH_SCRATCH]]/deno"
+                ]
+            },
+            "STEPS": [
+                {
+                    "INVOCATION_FILE": "[[NIPOPPY_DPATH_PIPELINES]]/[[PIPELINE_NAME]]-[[PIPELINE_VERSION]]/invocation.json",
+                    "DESCRIPTOR_FILE": "[[NIPOPPY_DPATH_PIPELINES]]/[[PIPELINE_NAME]]-[[PIPELINE_VERSION]]/descriptor.json",
+                    "ANALYSIS_LEVEL": "group",
+                    "GENERATE_PYBIDS_DATABASE": false
+                }
+            ]
+        },
+        {
             "NAME": "fmriprep",
             "VERSION": "24.1.1",
             "CONTAINER_INFO": {

--- a/nipoppy/data/examples/sample_pipelines/bids-validator-2.0.3/descriptor.json
+++ b/nipoppy/data/examples/sample_pipelines/bids-validator-2.0.3/descriptor.json
@@ -1,0 +1,211 @@
+{
+    "name": "bids-validator",
+    "description": "bids-validator",
+    "tool-version": "2.0.3",
+    "schema-version": "0.5",
+    "command-line": "[[NIPOPPY_CONTAINER_COMMAND]] [[NIPOPPY_FPATH_CONTAINER]] run -ERWN jsr:@bids/validator [DATASET_DIRECTORY] [HELP] [VERSION] [JSON] [SCHEMA] [CONFIG] [MAX_ROWS] [VERBOSE] [IGNORE_WARNINGS] [IGNORE_NIFTI_HEADERS] [DEBUG] [FILENAME_MODE] [BLACKLIST_MODALITIES] [RECURSIVE] [PRUNE] [OUTFILE] [COLOR] [NO_COLOR]",
+    "inputs": [
+        {
+            "id": "dataset_directory",
+            "name": "dataset_directory",
+            "description": "The root folder of the dataset to validate.",
+            "optional": false,
+            "type": "String",
+            "value-key": "[DATASET_DIRECTORY]"
+        },
+        {
+            "id": "help",
+            "name": "help",
+            "description": "Show this help.",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[HELP]",
+            "command-line-flag": "--help"
+        },
+        {
+            "id": "version",
+            "name": "version",
+            "description": "Show the version number for this program.",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[VERSION]",
+            "command-line-flag": "--version"
+        },
+        {
+            "id": "json",
+            "name": "json",
+            "description": "Output machine readable JSON",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[JSON]",
+            "command-line-flag": "--json"
+        },
+        {
+            "id": "schema",
+            "name": "schema",
+            "description": "Specify a schema version to use for validation (URL or tag)",
+            "optional": true,
+            "type": "String",
+            "value-key": "[SCHEMA]",
+            "command-line-flag": "--schema"
+        },
+        {
+            "id": "config",
+            "name": "config",
+            "description": "Path to a JSON configuration file",
+            "optional": true,
+            "type": "File",
+            "value-key": "[CONFIG]",
+            "command-line-flag": "--config"
+        },
+        {
+            "id": "max_rows",
+            "name": "max_rows",
+            "description": "Maximum number of rows to validate in TSVs. Use 0 to validate headers only. Use -1 to validate all.",
+            "optional": true,
+            "default-value": 1000,
+            "type": "Number",
+            "value-key": "[MAX_ROWS]",
+            "command-line-flag": "--max-rows"
+        },
+        {
+            "id": "verbose",
+            "name": "verbose",
+            "description": "Log more extensive information about issues.",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[VERBOSE]",
+            "command-line-flag": "--verbose"
+        },
+        {
+            "id": "ignore_warnings",
+            "name": "ignore_warnings",
+            "description": "Disregard non-critical issues.",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[IGNORE_WARNINGS]",
+            "command-line-flag": "--ignoreWarnings"
+        },
+        {
+            "id": "ignore_nifti_headers",
+            "name": "ignore_nifti_headers",
+            "description": "Disregard NIfTI header content during validation.",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[IGNORE_NIFTI_HEADERS]",
+            "command-line-flag": "--ignoreNiftiHeaders"
+        },
+        {
+            "id": "debug",
+            "name": "debug",
+            "description": "Enable debug output.",
+            "optional": true,
+            "default-value": "ERROR",
+            "value-choices": [
+                "NOTSET",
+                "DEBUG",
+                "INFO",
+                "WARN",
+                "ERROR",
+                "CRITICAL"
+            ],
+            "type": "String",
+            "value-key": "[DEBUG]",
+            "command-line-flag": "--debug"
+        },
+        {
+            "id": "filename_mode",
+            "name": "filename_mode",
+            "description": "Enable filename checks for newline separated filenames read from stdin.",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FILENAME_MODE]",
+            "command-line-flag": "--filenameMode"
+        },
+        {
+            "id": "blacklist_modalities",
+            "name": "blacklist_modalities",
+            "description": "Array of modalities to error on if detected.",
+            "optional": true,
+            "list": true,
+            "value-choices": [
+                "mri",
+                "eeg",
+                "ieeg",
+                "meg",
+                "beh",
+                "pet",
+                "micr",
+                "motion",
+                "nirs",
+                "mrs"
+            ],
+            "type": "String",
+            "value-key": "[BLACKLIST_MODALITIES]",
+            "command-line-flag": "--blacklistModalities"
+        },
+        {
+            "id": "recursive",
+            "name": "recursive",
+            "description": "Validate datasets found in derivatives directories in addition to root dataset.",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[RECURSIVE]",
+            "command-line-flag": "--recursive"
+        },
+        {
+            "id": "prune",
+            "name": "prune",
+            "description": "Prune derivatives and sourcedata directories on load (disables -r and will underestimate dataset size).",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[PRUNE]",
+            "command-line-flag": "--prune"
+        },
+        {
+            "id": "outfile",
+            "name": "outfile",
+            "description": "File to write validation results to.",
+            "optional": true,
+            "type": "File",
+            "value-key": "[OUTFILE]",
+            "command-line-flag": "--outfile"
+        },
+        {
+            "id": "color",
+            "name": "color",
+            "description": "Enable color output (defaults to detected support)",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[COLOR]",
+            "command-line-flag": "--color"
+        },
+        {
+            "id": "no_color",
+            "name": "no_color",
+            "description": "Disable color output (defaults to detected support)",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[NO_COLOR]",
+            "command-line-flag": "--no-color"
+        }
+    ],
+    "groups": [
+        {
+            "id": "color_group",
+            "name": "color_group",
+            "description": "This is a group for the mutually exclusive color options.",
+            "members": [
+                "color",
+                "no_color"
+            ],
+            "mutually-exclusive": true
+        }
+    ],
+    "tags": {},
+    "suggested-resources": {
+        "cpu-cores": 1,
+        "ram": 1,
+        "walltime-estimate": 60
+    }
+}

--- a/nipoppy/data/examples/sample_pipelines/bids-validator-2.0.3/invocation.json
+++ b/nipoppy/data/examples/sample_pipelines/bids-validator-2.0.3/invocation.json
@@ -1,3 +1,4 @@
 {
-    "dataset_directory": "[[NIPOPPY_DPATH_BIDS]]"
+    "dataset_directory": "[[NIPOPPY_DPATH_BIDS]]",
+    "schema": "latest"
 }

--- a/nipoppy/data/examples/sample_pipelines/bids-validator-2.0.3/invocation.json
+++ b/nipoppy/data/examples/sample_pipelines/bids-validator-2.0.3/invocation.json
@@ -1,0 +1,3 @@
+{
+    "dataset_directory": "[[NIPOPPY_DPATH_BIDS]]"
+}

--- a/tests/test_default_config.py
+++ b/tests/test_default_config.py
@@ -196,6 +196,7 @@ def test_boutiques_descriptors(fpath_descriptor):
 @pytest.mark.parametrize(
     "pipeline_name,pipeline_version",
     [
+        ("bids-validator", "2.0.3"),
         ("fmriprep", "20.2.7"),
         ("fmriprep", "23.1.3"),
         ("fmriprep", "24.1.1"),


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #530

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Add config and Boutiques files for the latest [BIDS validator](https://github.com/bids-standard/bids-validator)
- Note that the new BIDS validator is not containerized, but it is run through the `deno` JavaScript runtime, which has a container, so this is what I used

BIDS validator help (for verifying the Boutiques descriptor) message:
![Screenshot 2025-03-06 at 3 54 14 PM](https://github.com/user-attachments/assets/5737b809-2c8d-4f4d-acce-118230e54f4b)

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions
