### PR TITLE
[BUG] Add validation for non-alphanumeric characters in `participant_id` and `session_id` in manifest

### DIFF
--- a/nipoppy/utils.py
+++ b/nipoppy/utils.py
@@ -81,7 +81,7 @@ def check_participant_id(participant_id: Optional[str], raise_error=False):
     if participant_id.startswith(BIDS_SUBJECT_PREFIX):
         if raise_error:
             raise ValueError(
-                f'Participant ID should not start with "{BIDS_SUBJECT_PREFIX}"'
+                f'Invalid participant ID: should not start with "{BIDS_SUBJECT_PREFIX}"'
                 f", got {participant_id}"
             )
         else:
@@ -115,7 +115,7 @@ def check_session_id(session_id: Optional[str], raise_error=False):
     if session_id.startswith(BIDS_SESSION_PREFIX):
         if raise_error:
             raise ValueError(
-                f'Session ID should not start with "{BIDS_SESSION_PREFIX}"'
+                f'Invalid session ID: should not start with "{BIDS_SESSION_PREFIX}"'
                 f", got {session_id}"
             )
         else:

--- a/nipoppy/utils.py
+++ b/nipoppy/utils.py
@@ -57,14 +57,20 @@ def session_id_to_bids_session_id(session_id: Optional[str]) -> str:
 
 
 def check_participant_id(participant_id: Optional[str], raise_error=False):
-    """Make sure a participant ID does not have the BIDS prefix.
+    """Make sure a participant ID is valid.
+
+    Specifically:
+    - Check that it does not have the 'sub-' prefix
+    - Check that it only has alphanumeric characters
 
     Parameters
     ----------
     participant_id : Optional[str]
         The participant ID to check. If None, returns None.
-    strict : bool, optional
-        Whether to raise an error if the participant ID has the prefix, by default False
+    raise_error : bool, optional
+        Whether to raise an error if the participant ID has the prefix, by default
+        False. Note: an error is always raised if the participant ID contains
+        non-alphanumeric characters.
 
     Returns
     -------
@@ -85,20 +91,32 @@ def check_participant_id(participant_id: Optional[str], raise_error=False):
                 f", got {participant_id}"
             )
         else:
-            return participant_id.removeprefix(BIDS_SUBJECT_PREFIX)
+            participant_id = participant_id.removeprefix(BIDS_SUBJECT_PREFIX)
+
+    if not participant_id.isalnum():
+        raise ValueError(
+            f"Invalid participant ID: must only contain alphanumeric characters, "
+            f"got {participant_id}"
+        )
 
     return participant_id
 
 
 def check_session_id(session_id: Optional[str], raise_error=False):
-    """Make sure a session ID does not have the BIDS prefix.
+    """Make sure a session ID is valid.
+
+    Specifically:
+    - Check that it does not have the 'ses-' prefix
+    - Check that it only has alphanumeric characters
 
     Parameters
     ----------
-    session_id : Optional[str]
-        The session ID to check. If None, returns None.
-    strict : bool, optional
-        Whether to raise an error if the session ID has the prefix, by default False
+    participant_id : Optional[str]
+        The participant ID to check. If None, returns None.
+    raise_error : bool, optional
+        Whether to raise an error if the session ID has the prefix, by default
+        False. Note: an error is always raised if the session ID contains
+        non-alphanumeric characters.
 
     Returns
     -------
@@ -119,7 +137,14 @@ def check_session_id(session_id: Optional[str], raise_error=False):
                 f", got {session_id}"
             )
         else:
-            return session_id.removeprefix(BIDS_SESSION_PREFIX)
+            session_id = session_id.removeprefix(BIDS_SESSION_PREFIX)
+
+    if not session_id.isalnum():
+        raise ValueError(
+            f"Invalid session ID: must only contain alphanumeric characters, "
+            f"got {session_id}"
+        )
+
     return session_id
 
 

--- a/tests/data/manifest4.tsv
+++ b/tests/data/manifest4.tsv
@@ -1,0 +1,5 @@
+participant_id	visit_id	session_id	datatype
+01	BL	BL	['anat']
+01	M12	M12	['anat']
+02	BL	BL	['anat','dwi']
+02	M1_12	M12	['anat','dwi']

--- a/tests/data/manifest_invalid5.tsv
+++ b/tests/data/manifest_invalid5.tsv
@@ -1,0 +1,5 @@
+participant_id	visit_id	session_id	datatype
+P01	BL	BL	['anat']
+P01	M12	M12	['anat']
+P02	BL	BL	['anat','dwi']
+P_02	M12	M12	['anat','dwi']

--- a/tests/data/manifest_invalid6.tsv
+++ b/tests/data/manifest_invalid6.tsv
@@ -1,0 +1,5 @@
+participant_id	visit_id	session_id	datatype
+P01	BL	BL	['anat']
+P01	M12	M12	['anat']
+P02	BL	BL	['anat','dwi']
+P02	M12	M_12	['anat','dwi']

--- a/tests/test_tabular_manifest.py
+++ b/tests/test_tabular_manifest.py
@@ -16,6 +16,7 @@ from .conftest import DPATH_TEST_DATA
         DPATH_TEST_DATA / "manifest1.tsv",
         DPATH_TEST_DATA / "manifest2.tsv",
         DPATH_TEST_DATA / "manifest3.tsv",
+        DPATH_TEST_DATA / "manifest4.tsv",
     ],
 )
 @pytest.mark.parametrize("validate", [True, False])
@@ -36,6 +37,8 @@ def test_load_keep_extra_cols():
     [
         (DPATH_TEST_DATA / "manifest1.tsv", True),
         (DPATH_TEST_DATA / "manifest2.tsv", True),
+        (DPATH_TEST_DATA / "manifest3.tsv", True),
+        (DPATH_TEST_DATA / "manifest4.tsv", True),
         (DPATH_TEST_DATA / "manifest_invalid1.tsv", False),
         (DPATH_TEST_DATA / "manifest_invalid2.tsv", False),
         (DPATH_TEST_DATA / "manifest_invalid3.tsv", False),

--- a/tests/test_tabular_manifest.py
+++ b/tests/test_tabular_manifest.py
@@ -40,6 +40,8 @@ def test_load_keep_extra_cols():
         (DPATH_TEST_DATA / "manifest_invalid2.tsv", False),
         (DPATH_TEST_DATA / "manifest_invalid3.tsv", False),
         (DPATH_TEST_DATA / "manifest_invalid4.tsv", False),
+        (DPATH_TEST_DATA / "manifest_invalid5.tsv", False),
+        (DPATH_TEST_DATA / "manifest_invalid6.tsv", False),
     ],
 )
 def test_validate(fpath, is_valid):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -55,15 +55,19 @@ def test_session_id_to_bids_session_id(session, expected):
         ("sub-01", True, False, None),
         ("01", True, True, "01"),
         (None, True, True, None),
+        ("P-01", True, False, None),
+        ("sub_01", False, False, None),
     ],
 )
 def test_check_participant_id(participant_id, raise_error, is_valid, expected):
     with (
-        pytest.raises(ValueError, match="Participant ID should not start with")
+        pytest.raises(ValueError, match="Invalid participant ID")
         if not is_valid
         else nullcontext()
     ):
-        assert check_participant_id(participant_id, raise_error=raise_error) == expected
+        output = check_participant_id(participant_id, raise_error=raise_error)
+        if is_valid:
+            assert output == expected
 
 
 @pytest.mark.parametrize(
@@ -75,15 +79,19 @@ def test_check_participant_id(participant_id, raise_error, is_valid, expected):
         ("ses-1", True, False, None),
         ("1", True, True, "1"),
         (None, True, True, None),
+        ("-01", True, False, None),
+        ("1_", False, False, None),
     ],
 )
 def test_check_session_id(session_id, raise_error, is_valid, expected):
     with (
-        pytest.raises(ValueError, match="Session ID should not start with")
+        pytest.raises(ValueError, match="Invalid session ID")
         if not is_valid
         else nullcontext()
     ):
-        assert check_session_id(session_id, raise_error=raise_error) == expected
+        output = check_session_id(session_id, raise_error=raise_error)
+        if is_valid:
+            assert output == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #545

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Throw error if `participant_id` or `session_id` has non-alphanumeric characters
- `visit_id` can still have non-alphanumeric characters

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions
