### PR TITLE
[ENH] Add `PIPELINE_VARIABLES` to global config

### DIFF
--- a/nipoppy/config/main.py
+++ b/nipoppy/config/main.py
@@ -72,8 +72,6 @@ class PipelineVariables(BaseModel):
         """Convert fields to defaultdicts."""
 
         def _to_defaultdict(nested_dict: dict, level: int):
-            if not isinstance(nested_dict, dict):
-                return nested_dict
             if level == 0:
                 return nested_dict
             return defaultdict(

--- a/nipoppy/config/main.py
+++ b/nipoppy/config/main.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from pathlib import Path
 from typing import Any, Optional
 
-from pydantic import ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from typing_extensions import Self
 
 from nipoppy.config.container import _SchemaWithContainerConfig
@@ -14,6 +15,35 @@ from nipoppy.env import BIDS_SESSION_PREFIX, StrOrPathLike
 from nipoppy.layout import DEFAULT_LAYOUT_INFO
 from nipoppy.tabular.dicom_dir_map import DicomDirMap
 from nipoppy.utils import apply_substitutions_to_json, load_json
+
+
+class PipelineVariables(BaseModel):
+    """Schema for pipeline variables in main config."""
+
+    BIDSIFICATION: dict[str, dict[str, dict[str, str]]] = Field(
+        default_factory=lambda: defaultdict(lambda: defaultdict(dict)),
+        description=(
+            "Variables for the BIDSification pipelines. This should be a nested "
+            "dictionary with these levels: "
+            "pipeline name -> pipeline version -> variable name -> variable value"
+        ),
+    )
+    PROCESSING: dict[str, dict[str, dict[str, str]]] = Field(
+        default_factory=lambda: defaultdict(lambda: defaultdict(dict)),
+        description=(
+            "Variables for the processing pipelines. This should be a nested "
+            "dictionary with these levels: "
+            "pipeline name -> pipeline version -> variable name -> variable value"
+        ),
+    )
+    EXTRACTION: dict[str, dict[str, dict[str, str]]] = Field(
+        default_factory=lambda: defaultdict(lambda: defaultdict(dict)),
+        description=(
+            "Variables for the extraction pipelines. This should be a nested "
+            "dictionary with these levels: "
+            "pipeline name -> pipeline version -> variable name -> variable value"
+        ),
+    )
 
 
 class Config(_SchemaWithContainerConfig):
@@ -60,6 +90,13 @@ class Config(_SchemaWithContainerConfig):
             "Top-level mapping for replacing placeholder expressions in the rest "
             "of the config file. Note: the replacement only happens if the config "
             "is loaded from a file with :func:`nipoppy.config.main.Config.load`"
+        ),
+    )
+    PIPELINE_VARIABLES: PipelineVariables = Field(
+        default=PipelineVariables(),
+        description=(
+            "Pipeline-specific variables. Typically these are paths to external "
+            "resources needed by a pipeline that need to be provided by the user"
         ),
     )
     CUSTOM: dict = Field(

--- a/nipoppy/config/pipeline.py
+++ b/nipoppy/config/pipeline.py
@@ -200,11 +200,12 @@ class ExtractionPipelineConfig(BasePipelineConfig):
     @model_validator(mode="after")
     def validate_after(self):
         """
-        Validate the config instantiation after instantiation.
+        Validate the config after instantiation.
 
         Specifically:
         - Make sure that PROC_DEPENDENCIES is not empty
         """
+        super().validate_after()
         if len(self.PROC_DEPENDENCIES) == 0:
             raise ValueError(
                 "PROC_DEPENDENCIES is an empty list for extraction pipeline "

--- a/nipoppy/data/examples/sample_global_config.json
+++ b/nipoppy/data/examples/sample_global_config.json
@@ -22,5 +22,56 @@
             "--cleanenv"
         ]
     },
+    "PIPELINE_VARIABLES": {
+        "BIDSIFICATION": {
+            "dcm2bids": {
+                "3.1.0": {
+                    "DCM2BIDS_CONFIG_FILE": "[[DCM2BIDS_CONFIG_FILE]]"
+                },
+                "3.2.0": {
+                    "DCM2BIDS_CONFIG_FILE": "[[DCM2BIDS_CONFIG_FILE]]"
+                }
+            },
+            "heudiconv": {
+                "0.12.2": {
+                    "HEUDICONV_HEURISTIC_FILE": "[[HEUDICONV_HEURISTIC_FILE]]"
+                }
+            }
+        },
+        "PROCESSING": {
+            "fmriprep": {
+                "20.2.7": {
+                    "FREESURFER_LICENSE_FILE": "[[FREESURFER_LICENSE_FILE]]",
+                    "TEMPLATEFLOW_HOME": "[[TEMPLATEFLOW_HOME]]"
+                },
+                "23.1.3": {
+                    "FREESURFER_LICENSE_FILE": "[[FREESURFER_LICENSE_FILE]]",
+                    "TEMPLATEFLOW_HOME": "[[TEMPLATEFLOW_HOME]]"
+                },
+                "24.1.1": {
+                    "FREESURFER_LICENSE_FILE": "[[FREESURFER_LICENSE_FILE]]",
+                    "TEMPLATEFLOW_HOME": "[[TEMPLATEFLOW_HOME]]"
+                }
+            },
+            "mriqc": {
+                "23.1.0": {
+                    "TEMPLATEFLOW_HOME": "[[TEMPLATEFLOW_HOME]]"
+                }
+            },
+            "qsiprep": {
+                "0.23.0": {
+                    "FREESURFER_LICENSE_FILE": "[[FREESURFER_LICENSE_FILE]]",
+                    "TEMPLATEFLOW_HOME": "[[TEMPLATEFLOW_HOME]]"
+                }
+            }
+        },
+        "EXTRACTION": {
+            "fs_stats": {
+                "0.2.0": {
+                    "FREESURFER_LICENSE_FILE": "[[FREESURFER_LICENSE_FILE]]"
+                }
+            }
+        }
+    },
     "CUSTOM": {}
 }

--- a/nipoppy/data/examples/sample_pipelines/bids/bidscoin-4.3.2/config.json
+++ b/nipoppy/data/examples/sample_pipelines/bids/bidscoin-4.3.2/config.json
@@ -21,5 +21,6 @@
             "ANALYSIS_LEVEL": "participant",
             "UPDATE_DOUGHNUT": true
         }
-    ]
+    ],
+    "PIPELINE_TYPE": "bidsification"
 }

--- a/nipoppy/data/examples/sample_pipelines/bids/dcm2bids-3.1.0/config.json
+++ b/nipoppy/data/examples/sample_pipelines/bids/dcm2bids-3.1.0/config.json
@@ -24,5 +24,6 @@
             },
             "UPDATE_DOUGHNUT": true
         }
-    ]
+    ],
+    "PIPELINE_TYPE": "bidsification"
 }

--- a/nipoppy/data/examples/sample_pipelines/bids/dcm2bids-3.2.0/config.json
+++ b/nipoppy/data/examples/sample_pipelines/bids/dcm2bids-3.2.0/config.json
@@ -24,5 +24,6 @@
             },
             "UPDATE_DOUGHNUT": true
         }
-    ]
+    ],
+    "PIPELINE_TYPE": "bidsification"
 }

--- a/nipoppy/data/examples/sample_pipelines/bids/heudiconv-0.12.2/config.json
+++ b/nipoppy/data/examples/sample_pipelines/bids/heudiconv-0.12.2/config.json
@@ -23,5 +23,6 @@
             },
             "UPDATE_DOUGHNUT": true
         }
-    ]
+    ],
+    "PIPELINE_TYPE": "bidsification"
 }

--- a/nipoppy/data/examples/sample_pipelines/extraction/fs_stats-0.2.0/config.json
+++ b/nipoppy/data/examples/sample_pipelines/extraction/fs_stats-0.2.0/config.json
@@ -26,5 +26,6 @@
             "DESCRIPTOR_FILE": "[[NIPOPPY_DPATH_PIPELINES]]/extraction/[[PIPELINE_NAME]]-[[PIPELINE_VERSION]]/descriptor.json",
             "ANALYSIS_LEVEL": "group"
         }
-    ]
+    ],
+    "PIPELINE_TYPE": "extraction"
 }

--- a/nipoppy/data/examples/sample_pipelines/extraction/static_FC-0.1.0/config.json
+++ b/nipoppy/data/examples/sample_pipelines/extraction/static_FC-0.1.0/config.json
@@ -12,5 +12,6 @@
             "INVOCATION_FILE": "[[NIPOPPY_DPATH_PIPELINES]]/extraction/[[PIPELINE_NAME]]-[[PIPELINE_VERSION]]/invocation.json",
             "DESCRIPTOR_FILE": "[[NIPOPPY_DPATH_PIPELINES]]/extraction/[[PIPELINE_NAME]]-[[PIPELINE_VERSION]]/descriptor.json"
         }
-    ]
+    ],
+    "PIPELINE_TYPE": "extraction"
 }

--- a/nipoppy/data/examples/sample_pipelines/proc/fmriprep-20.2.7/config.json
+++ b/nipoppy/data/examples/sample_pipelines/proc/fmriprep-20.2.7/config.json
@@ -22,5 +22,6 @@
             "DESCRIPTOR_FILE": "[[NIPOPPY_DPATH_PIPELINES]]/proc/[[PIPELINE_NAME]]-[[PIPELINE_VERSION]]/descriptor.json",
             "TRACKER_CONFIG_FILE": "[[NIPOPPY_DPATH_PIPELINES]]/proc/[[PIPELINE_NAME]]-[[PIPELINE_VERSION]]/tracker_config.json"
         }
-    ]
+    ],
+    "PIPELINE_TYPE": "processing"
 }

--- a/nipoppy/data/examples/sample_pipelines/proc/fmriprep-23.1.3/config.json
+++ b/nipoppy/data/examples/sample_pipelines/proc/fmriprep-23.1.3/config.json
@@ -22,5 +22,6 @@
             "DESCRIPTOR_FILE": "[[NIPOPPY_DPATH_PIPELINES]]/proc/[[PIPELINE_NAME]]-[[PIPELINE_VERSION]]/descriptor.json",
             "TRACKER_CONFIG_FILE": "[[NIPOPPY_DPATH_PIPELINES]]/proc/[[PIPELINE_NAME]]-[[PIPELINE_VERSION]]/tracker_config.json"
         }
-    ]
+    ],
+    "PIPELINE_TYPE": "processing"
 }

--- a/nipoppy/data/examples/sample_pipelines/proc/fmriprep-24.1.1/config.json
+++ b/nipoppy/data/examples/sample_pipelines/proc/fmriprep-24.1.1/config.json
@@ -22,5 +22,6 @@
             "DESCRIPTOR_FILE": "[[NIPOPPY_DPATH_PIPELINES]]/proc/[[PIPELINE_NAME]]-[[PIPELINE_VERSION]]/descriptor.json",
             "TRACKER_CONFIG_FILE": "[[NIPOPPY_DPATH_PIPELINES]]/proc/[[PIPELINE_NAME]]-[[PIPELINE_VERSION]]/tracker_config.json"
         }
-    ]
+    ],
+    "PIPELINE_TYPE": "processing"
 }

--- a/nipoppy/data/examples/sample_pipelines/proc/freesurfer-6.0.1/config.json
+++ b/nipoppy/data/examples/sample_pipelines/proc/freesurfer-6.0.1/config.json
@@ -6,5 +6,6 @@
         {
             "TRACKER_CONFIG_FILE": "[[NIPOPPY_DPATH_PIPELINES]]/proc/[[PIPELINE_NAME]]-[[PIPELINE_VERSION]]/tracker_config.json"
         }
-    ]
+    ],
+    "PIPELINE_TYPE": "processing"
 }

--- a/nipoppy/data/examples/sample_pipelines/proc/freesurfer-7.3.2/config.json
+++ b/nipoppy/data/examples/sample_pipelines/proc/freesurfer-7.3.2/config.json
@@ -6,5 +6,6 @@
         {
             "TRACKER_CONFIG_FILE": "[[NIPOPPY_DPATH_PIPELINES]]/proc/[[PIPELINE_NAME]]-[[PIPELINE_VERSION]]/tracker_config.json"
         }
-    ]
+    ],
+    "PIPELINE_TYPE": "processing"
 }

--- a/nipoppy/data/examples/sample_pipelines/proc/mriqc-23.1.0/config.json
+++ b/nipoppy/data/examples/sample_pipelines/proc/mriqc-23.1.0/config.json
@@ -20,5 +20,6 @@
             "DESCRIPTOR_FILE": "[[NIPOPPY_DPATH_PIPELINES]]/proc/[[PIPELINE_NAME]]-[[PIPELINE_VERSION]]/descriptor.json",
             "TRACKER_CONFIG_FILE": "[[NIPOPPY_DPATH_PIPELINES]]/proc/[[PIPELINE_NAME]]-[[PIPELINE_VERSION]]/tracker_config.json"
         }
-    ]
+    ],
+    "PIPELINE_TYPE": "processing"
 }

--- a/nipoppy/data/examples/sample_pipelines/proc/qsiprep-0.23.0/config.json
+++ b/nipoppy/data/examples/sample_pipelines/proc/qsiprep-0.23.0/config.json
@@ -22,5 +22,6 @@
             "DESCRIPTOR_FILE": "[[NIPOPPY_DPATH_PIPELINES]]/proc/[[PIPELINE_NAME]]-[[PIPELINE_VERSION]]/descriptor.json",
             "TRACKER_CONFIG_FILE": "[[NIPOPPY_DPATH_PIPELINES]]/proc/[[PIPELINE_NAME]]-[[PIPELINE_VERSION]]/tracker_config.json"
         }
-    ]
+    ],
+    "PIPELINE_TYPE": "processing"
 }

--- a/nipoppy/env.py
+++ b/nipoppy/env.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from enum import Enum
 from typing import TypeVar
 
 StrOrPathLike = TypeVar("StrOrPathLike", str, os.PathLike)
@@ -21,6 +22,14 @@ IS_TESTING = "pytest" in sys.modules
 
 # file extensions
 EXT_TAR = ".tar"
+
+
+class PipelineTypeEnum(str, Enum):
+    """Pipeline types."""
+
+    BIDSIFICATION = "bidsification"
+    PROCESSING = "processing"
+    EXTRACTION = "extraction"
 
 
 class ReturnCode:

--- a/nipoppy/workflows/pipeline.py
+++ b/nipoppy/workflows/pipeline.py
@@ -243,7 +243,12 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
             )
         self.logger.info(f"Loading descriptor from {fpath_descriptor}")
         descriptor = load_json(fpath_descriptor)
-        descriptor = self.config.apply_substitutions_to_json(descriptor)
+        descriptor = self.config.apply_pipeline_variables(
+            pipeline_type=self.pipeline_config.PIPELINE_TYPE,
+            pipeline_name=self.pipeline_config.NAME,
+            pipeline_version=self.pipeline_config.VERSION,
+            json_obj=descriptor,
+        )
         return descriptor
 
     @cached_property
@@ -257,7 +262,12 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
             )
         self.logger.info(f"Loading invocation from {fpath_invocation}")
         invocation = load_json(fpath_invocation)
-        invocation = self.config.apply_substitutions_to_json(invocation)
+        invocation = self.config.apply_pipeline_variables(
+            pipeline_type=self.pipeline_config.PIPELINE_TYPE,
+            pipeline_name=self.pipeline_config.NAME,
+            pipeline_version=self.pipeline_config.VERSION,
+            json_obj=invocation,
+        )
         return invocation
 
     @cached_property
@@ -345,12 +355,16 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
                 and pipeline_config_candidate.VERSION == pipeline_version
             ):
                 # once there is a match we apply the substitutions
-                pipeline_config_json = self.config.apply_substitutions_to_json(
-                    self.process_template_json(
+                pipeline_config_json = self.config.apply_pipeline_variables(
+                    pipeline_type=pipeline_config_candidate.PIPELINE_TYPE,
+                    pipeline_name=pipeline_name,
+                    pipeline_version=pipeline_version,
+                    json_obj=self.process_template_json(
                         pipeline_config_candidate.model_dump(mode="json"),
                         objs=[self, self.layout],
                     ),
                 )
+
                 return self.config.propagate_container_config_to_pipeline(
                     pipeline_class(**pipeline_config_json)
                 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import pytest_mock
 from fids.fids import create_fake_bids_dataset
 
 from nipoppy.config.main import Config
-from nipoppy.env import StrOrPathLike
+from nipoppy.env import PipelineTypeEnum, StrOrPathLike
 from nipoppy.layout import DatasetLayout
 from nipoppy.tabular.doughnut import Doughnut
 from nipoppy.tabular.manifest import Manifest
@@ -112,14 +112,23 @@ def create_pipeline_config_files(
     extraction_pipelines: Optional[list[dict]] = None,
 ):
     """Create pipeline bundles (inside bids/proc/extraction subdirectories)."""
-    for pipeline_config_list, dname in [
-        (bids_pipelines, DatasetLayout.dname_catalog_bids),
-        (proc_pipelines, DatasetLayout.dname_catalog_proc),
-        (extraction_pipelines, DatasetLayout.dname_catalog_extraction),
+    for pipeline_config_list, pipeline_type, dname in [
+        (
+            bids_pipelines,
+            PipelineTypeEnum.BIDSIFICATION,
+            DatasetLayout.dname_catalog_bids,
+        ),
+        (proc_pipelines, PipelineTypeEnum.PROCESSING, DatasetLayout.dname_catalog_proc),
+        (
+            extraction_pipelines,
+            PipelineTypeEnum.EXTRACTION,
+            DatasetLayout.dname_catalog_extraction,
+        ),
     ]:
         if pipeline_config_list is None:
             continue
         for pipeline_config in pipeline_config_list:
+            pipeline_config["PIPELINE_TYPE"] = pipeline_type
             fpath_config = (
                 dpath_pipelines
                 / dname

--- a/tests/test_config_main.py
+++ b/tests/test_config_main.py
@@ -14,6 +14,8 @@ from nipoppy.utils import FPATH_SAMPLE_CONFIG
 
 from .conftest import DPATH_TEST_DATA
 
+FIELDS_PIPELINE_VARIABLES = ["BIDSIFICATION", "PROCESSING", "EXTRACTION"]
+
 REQUIRED_FIELDS_CONFIG = ["DATASET_NAME", "VISIT_IDS"]
 FIELDS_CONFIG = REQUIRED_FIELDS_CONFIG + [
     "SESSION_IDS",
@@ -22,6 +24,7 @@ FIELDS_CONFIG = REQUIRED_FIELDS_CONFIG + [
     "CONTAINER_CONFIG",
     "DICOM_DIR_MAP_FILE",
     "DICOM_DIR_PARTICIPANT_FIRST",
+    "PIPELINE_VARIABLES",
 ]
 
 
@@ -46,6 +49,15 @@ def test_fields(valid_config_data: dict):
 def test_no_extra_fields(valid_config_data):
     with pytest.raises(ValidationError):
         Config(**valid_config_data, NOT_A_FIELD="x")
+
+
+def test_pipeline_variables(valid_config_data: dict):
+    config = Config(
+        **{k: v for (k, v) in valid_config_data.items() if k in REQUIRED_FIELDS_CONFIG}
+    )
+    pipeline_vars = config.PIPELINE_VARIABLES
+    for field in FIELDS_PIPELINE_VARIABLES:
+        assert hasattr(pipeline_vars, field)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config_main.py
+++ b/tests/test_config_main.py
@@ -8,8 +8,9 @@ import pytest
 from pydantic import ValidationError
 
 from nipoppy.config.container import ContainerConfig
-from nipoppy.config.main import Config
+from nipoppy.config.main import Config, PipelineVariables
 from nipoppy.config.pipeline import BasePipelineConfig
+from nipoppy.env import PipelineTypeEnum
 from nipoppy.utils import FPATH_SAMPLE_CONFIG
 
 from .conftest import DPATH_TEST_DATA
@@ -37,6 +38,37 @@ def valid_config_data():
     }
 
 
+@pytest.fixture(scope="function")
+def pipeline_variables():
+    data = {
+        "BIDSIFICATION": {
+            "bids_pipeline": {
+                "0.0.1": {
+                    "bids1": "val1",
+                    "bids2": "val2",
+                },
+            },
+        },
+        "PROCESSING": {
+            "proc_pipeline": {
+                "0.1.0": {
+                    "proc1": "val1",
+                },
+                "0.2.0": {
+                    "proc1": "val1",
+                    "proc2": "val2",
+                },
+            },
+        },
+        "EXTRACTION": {
+            "extraction_pipeline": {
+                "1.0.0": {},
+            },
+        },
+    }
+    return PipelineVariables(**data)
+
+
 def test_fields(valid_config_data: dict):
     config = Config(
         **{k: v for (k, v) in valid_config_data.items() if k in REQUIRED_FIELDS_CONFIG}
@@ -49,15 +81,6 @@ def test_fields(valid_config_data: dict):
 def test_no_extra_fields(valid_config_data):
     with pytest.raises(ValidationError):
         Config(**valid_config_data, NOT_A_FIELD="x")
-
-
-def test_pipeline_variables(valid_config_data: dict):
-    config = Config(
-        **{k: v for (k, v) in valid_config_data.items() if k in REQUIRED_FIELDS_CONFIG}
-    )
-    pipeline_vars = config.PIPELINE_VARIABLES
-    for field in FIELDS_PIPELINE_VARIABLES:
-        assert hasattr(pipeline_vars, field)
 
 
 @pytest.mark.parametrize(
@@ -178,26 +201,6 @@ def test_save(tmp_path: Path, valid_config_data):
 
 
 @pytest.mark.parametrize(
-    "substitutions,json_obj,expected",
-    [
-        (
-            {"VALUE1": "AAA", "VALUE2": "BBB"},
-            {"KEY": "VALUE1 VALUE2"},
-            {"KEY": "AAA BBB"},
-        ),
-        (
-            {"VALUE1": "CCC", "VALUE2": "DDD"},
-            ["AAA BBB VALUE1", "VALUE2"],
-            ["AAA BBB CCC", "DDD"],
-        ),
-    ],
-)
-def test_apply_substitutions(valid_config_data, substitutions, json_obj, expected):
-    config = Config(**valid_config_data, SUBSTITUTIONS=substitutions)
-    assert config.apply_substitutions_to_json(json_obj) == expected
-
-
-@pytest.mark.parametrize(
     "path",
     [
         FPATH_SAMPLE_CONFIG,
@@ -265,3 +268,110 @@ def test_load_no_substitutions(
     assert (
         Config.load(fpath, apply_substitutions=apply_substitutions) == config_expected
     )
+
+
+@pytest.mark.parametrize(
+    "pipeline_type,pipeline_name,pipeline_version,json_obj,expected",
+    [
+        (
+            PipelineTypeEnum.BIDSIFICATION,
+            "bids_pipeline",
+            "0.0.1",
+            {"some_key": "123_[[bids1]]"},
+            {"some_key": "123_val1"},
+        ),
+        (
+            PipelineTypeEnum.PROCESSING,
+            "proc_pipeline",
+            "0.2.0",
+            {"[[proc1]]_key": "123_[[bids1]]"},
+            {"val1_key": "123_[[bids1]]"},
+        ),
+        (
+            PipelineTypeEnum.EXTRACTION,
+            "extraction_pipeline",
+            "1.0.0",
+            {"some_key": "123_[[bids1]]"},
+            {"some_key": "123_[[bids1]]"},
+        ),
+    ],
+)
+def test_apply_pipeline_variables(
+    valid_config_data,
+    pipeline_variables,
+    pipeline_type,
+    pipeline_name,
+    pipeline_version,
+    json_obj,
+    expected,
+):
+    config = Config(**valid_config_data)
+    config.PIPELINE_VARIABLES = pipeline_variables
+    assert (
+        config.apply_pipeline_variables(
+            pipeline_type, pipeline_name, pipeline_version, json_obj
+        )
+        == expected
+    )
+
+
+def test_pipeline_variables(valid_config_data: dict):
+    config = Config(
+        **{k: v for (k, v) in valid_config_data.items() if k in REQUIRED_FIELDS_CONFIG}
+    )
+    pipeline_vars = config.PIPELINE_VARIABLES
+    for field in FIELDS_PIPELINE_VARIABLES:
+        assert hasattr(pipeline_vars, field)
+
+
+def test_pipeline_variables_not_extra_fields():
+    with pytest.raises(ValidationError):
+        PipelineVariables(NOT_A_FIELD="x")
+
+
+@pytest.mark.parametrize(
+    "pipeline_type,pipeline_name,pipeline_version,expected",
+    [
+        (
+            PipelineTypeEnum.BIDSIFICATION,
+            "bids_pipeline",
+            "0.0.1",
+            {"bids1": "val1", "bids2": "val2"},
+        ),
+        (PipelineTypeEnum.PROCESSING, "proc_pipeline", "0.1.0", {"proc1": "val1"}),
+        (
+            PipelineTypeEnum.PROCESSING,
+            "proc_pipeline",
+            "0.2.0",
+            {"proc1": "val1", "proc2": "val2"},
+        ),
+        (PipelineTypeEnum.EXTRACTION, "extraction_pipelines", "1.0.0", {}),
+    ],
+)
+def test_pipeline_variables_get_variables(
+    pipeline_variables, pipeline_type, pipeline_name, pipeline_version, expected
+):
+    assert (
+        pipeline_variables.get_variables(pipeline_type, pipeline_name, pipeline_version)
+        == expected
+    )
+
+
+def test_pipeline_variables_get_variables_error_pipeline_type(pipeline_variables):
+    with pytest.raises(ValueError, match="Invalid pipeline type"):
+        pipeline_variables.get_variables("INVALID", "pipeline1", "version1")
+
+
+def test_pipeline_variables_get_variables_unknown(pipeline_variables):
+    assert (
+        pipeline_variables.get_variables(PipelineTypeEnum.PROCESSING, "xyz", "123")
+        == {}
+    )
+
+
+def test_pipeline_variables_validation(pipeline_variables):
+    # test the conversion to defaultdict
+    # any unknown pipeline should have an empty dict
+    assert pipeline_variables.BIDSIFICATION["unknown_pipeline"]["v1"] == {}
+    assert pipeline_variables.PROCESSING["unknown_pipeline2"]["v2"] == {}
+    assert pipeline_variables.EXTRACTION["unknown_pipeline3"]["v3"] == {}

--- a/tests/test_default_config.py
+++ b/tests/test_default_config.py
@@ -79,7 +79,7 @@ def single_subject_dataset(
 @pytest.fixture()
 def bids_pipeline_configs() -> list[BidsPipelineConfig]:
     return get_pipeline_configs(
-        DPATH_SAMPLE_PIPELINES / DatasetLayout.dname_catalog_bids, BasePipelineConfig
+        DPATH_SAMPLE_PIPELINES / DatasetLayout.dname_catalog_bids, BidsPipelineConfig
     )
 
 

--- a/tests/test_workflow_pipeline.py
+++ b/tests/test_workflow_pipeline.py
@@ -280,17 +280,19 @@ def test_descriptor_none(workflow: PipelineWorkflow):
 
 
 @pytest.mark.parametrize(
-    "substitutions,expected_descriptor",
+    "variables,expected_descriptor",
     [
-        ({"[[TO_REPLACE1]]": "value1"}, {"key1": "value1"}),
-        ({"TO_REPLACE1": "value1"}, {"key1": "[[value1]]"}),
+        ({"TO_REPLACE1": "value1"}, {"key1": "value1"}),
+        ({"[[TO_REPLACE1]]": "value1"}, {"key1": "[[TO_REPLACE1]]"}),
     ],
 )
-def test_descriptor_substitutions(
-    tmp_path: Path, workflow: PipelineWorkflow, substitutions, expected_descriptor
+def test_descriptor_pipeline_variables(
+    tmp_path: Path, workflow: PipelineWorkflow, variables, expected_descriptor
 ):
-    # set substitutions
-    workflow.config.SUBSTITUTIONS = substitutions
+    # set variables for substitution
+    workflow.config.PIPELINE_VARIABLES.PROCESSING[workflow.pipeline_name][
+        workflow.pipeline_version
+    ] = variables
 
     # set descriptor file and write descriptor content
     fpath_descriptor = tmp_path / "custom_pipeline.json"
@@ -333,17 +335,19 @@ def test_invocation_none(workflow: PipelineWorkflow):
 
 
 @pytest.mark.parametrize(
-    "substitutions,expected_invocation",
+    "variables,expected_invocation",
     [
-        ({"[[TO_REPLACE1]]": "value1"}, {"key1": "value1"}),
-        ({"TO_REPLACE1": "value1"}, {"key1": "[[value1]]"}),
+        ({"TO_REPLACE1": "value1"}, {"key1": "value1"}),
+        ({"[[TO_REPLACE1]]": "value1"}, {"key1": "[[TO_REPLACE1]]"}),
     ],
 )
-def test_invocation_substitutions(
-    tmp_path: Path, workflow: PipelineWorkflow, substitutions, expected_invocation
+def test_invocation_pipeline_variables(
+    tmp_path: Path, workflow: PipelineWorkflow, variables, expected_invocation
 ):
-    # set substitutions
-    workflow.config.SUBSTITUTIONS = substitutions
+    # set variables for substitution
+    workflow.config.PIPELINE_VARIABLES.PROCESSING[workflow.pipeline_name][
+        workflow.pipeline_version
+    ] = variables
 
     # set invocation file and write invocation content
     fpath_invocation = tmp_path / "invocation.json"

--- a/tests/test_workflow_pipeline.py
+++ b/tests/test_workflow_pipeline.py
@@ -294,13 +294,9 @@ def test_descriptor_substitutions(
 
     # set descriptor file and write descriptor content
     fpath_descriptor = tmp_path / "custom_pipeline.json"
-    workflow.pipeline_config = ProcPipelineConfig(
-        NAME=workflow.pipeline_name,
-        VERSION=workflow.pipeline_version,
-        STEPS=[
-            ProcPipelineStepConfig(DESCRIPTOR_FILE=fpath_descriptor, INVOCATION_FILE="")
-        ],
-    )
+    workflow.pipeline_config.STEPS = [
+        ProcPipelineStepConfig(DESCRIPTOR_FILE=fpath_descriptor, INVOCATION_FILE="")
+    ]
 
     fpath_descriptor.write_text(json.dumps({"key1": "[[TO_REPLACE1]]"}))
 
@@ -351,13 +347,10 @@ def test_invocation_substitutions(
 
     # set invocation file and write invocation content
     fpath_invocation = tmp_path / "invocation.json"
-    workflow.pipeline_config = ProcPipelineConfig(
-        NAME=workflow.pipeline_name,
-        VERSION=workflow.pipeline_version,
-        STEPS=[
-            ProcPipelineStepConfig(INVOCATION_FILE=fpath_invocation, DESCRIPTOR_FILE="")
-        ],
-    )
+    workflow.pipeline_config.STEPS = [
+        ProcPipelineStepConfig(INVOCATION_FILE=fpath_invocation, DESCRIPTOR_FILE="")
+    ]
+
     fpath_invocation.write_text(json.dumps({"key1": "[[TO_REPLACE1]]"}))
 
     assert workflow.invocation == expected_invocation
@@ -823,16 +816,13 @@ def test_run_cleanup(
     workflow: PipelineWorkflow,
     caplog: pytest.LogCaptureFixture,
 ):
-    pipeline_name = "my_pipeline"
-    pipeline_version = "1.0"
     workflow.n_success = n_success
     workflow.n_total = n_total
 
-    workflow.pipeline_config = ProcPipelineConfig(
-        NAME=pipeline_name,
-        VERSION=pipeline_version,
-        STEPS=[ProcPipelineStepConfig(ANALYSIS_LEVEL=analysis_level)],
-    )
+    workflow.pipeline_config.STEPS = [
+        ProcPipelineStepConfig(ANALYSIS_LEVEL=analysis_level)
+    ]
+
     workflow.run_cleanup()
 
     assert expected_message.format(n_success, n_total) in caplog.text


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #544

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Add `PIPELINE_VARIABLES` field to the global config
- Refactor existing substitutions into `PIPELINE_VARIABLES` -- for now keep them all in the default config, but eventually only add them when adding a pipeline to a dataset
- `SUBSTITUTIONS` is still there, I don't think we necessarily need to remove it but we can discuss
- Now the pipeline config Pydantic classes have a `PIPELINE_TYPE` field which is used to decide where the pipeline variables should go. Will be useful for knowing where to put files in `nipoppy pipeline install` too

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added
