### PR TITLE
[MAINT] Fix Pydantic `model_fields` deprecations

### DIFF
--- a/tests/test_config_boutiques.py
+++ b/tests/test_config_boutiques.py
@@ -16,7 +16,7 @@ def test_boutiques_config():
     boutiques_config = BoutiquesConfig()
     for field in FIELDS_BOUTIQUES:
         assert hasattr(boutiques_config, field)
-    assert len(boutiques_config.model_fields) == len(FIELDS_BOUTIQUES)
+    assert len(boutiques_config.model_dump()) == len(FIELDS_BOUTIQUES)
 
 
 def test_boutiques_config_no_extra_fields():

--- a/tests/test_config_container.py
+++ b/tests/test_config_container.py
@@ -40,7 +40,7 @@ def test_container_config(data):
     container_config = ContainerConfig(**data)
     for field in FIELDS_CONTAINER_CONFIG:
         assert hasattr(container_config, field)
-    assert len(container_config.model_fields) == len(FIELDS_CONTAINER_CONFIG)
+    assert len(container_config.model_dump()) == len(FIELDS_CONTAINER_CONFIG)
 
 
 @pytest.mark.parametrize(
@@ -131,7 +131,7 @@ def test_container_info(data):
     container_info = ContainerInfo(**data)
     for field in FIELDS_CONTAINER_INFO:
         assert hasattr(container_info, field)
-    assert len(container_info.model_fields) == len(FIELDS_CONTAINER_INFO)
+    assert len(container_info.model_dump()) == len(FIELDS_CONTAINER_INFO)
 
 
 def test_container_info_no_extra_fields():

--- a/tests/test_config_main.py
+++ b/tests/test_config_main.py
@@ -75,7 +75,7 @@ def test_fields(valid_config_data: dict):
     )
     for field in FIELDS_CONFIG:
         assert hasattr(config, field)
-    assert len(config.model_fields) == len(FIELDS_CONFIG)
+    assert len(config.model_dump()) == len(FIELDS_CONFIG)
 
 
 def test_no_extra_fields(valid_config_data):

--- a/tests/test_config_pipeline.py
+++ b/tests/test_config_pipeline.py
@@ -50,7 +50,7 @@ def test_fields(model_class, fields, valid_data):
     for field in fields:
         assert hasattr(config, field)
 
-    assert len(set(config.model_fields.keys())) == len(fields)
+    assert len(set(config.model_dump())) == len(fields)
 
 
 def test_fields_extraction_pipeline(valid_data):
@@ -60,7 +60,7 @@ def test_fields_extraction_pipeline(valid_data):
     )
     for field in FIELDS_EXTRACTION_PIPELINE:
         assert hasattr(config, field)
-    assert len(set(config.model_fields.keys())) == len(FIELDS_EXTRACTION_PIPELINE)
+    assert len(set(config.model_dump())) == len(FIELDS_EXTRACTION_PIPELINE)
 
 
 @pytest.mark.parametrize("model_class", [BasePipelineConfig, PipelineInfo])

--- a/tests/test_config_pipeline_step.py
+++ b/tests/test_config_pipeline_step.py
@@ -67,7 +67,7 @@ def test_field_base(step_class: type[BaseModel], fields, data_list):
         for field in fields:
             assert hasattr(pipeline_step_config, field)
 
-        assert len(set(pipeline_step_config.model_fields.keys())) == len(fields)
+        assert len(set(pipeline_step_config.model_dump())) == len(fields)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config_tracker.py
+++ b/tests/test_config_tracker.py
@@ -21,7 +21,7 @@ def test_fields(data):
     for field in FIELDS_STEP:
         assert hasattr(tracker_config, field)
 
-    assert len(set(tracker_config.model_fields.keys())) == len(FIELDS_STEP)
+    assert len(set(tracker_config.model_dump())) == len(FIELDS_STEP)
 
 
 def test_no_extra_field():

--- a/tests/test_tabular_bagel.py
+++ b/tests/test_tabular_bagel.py
@@ -34,7 +34,7 @@ from .conftest import DPATH_TEST_DATA
 )
 def test_model(data):
     bagel = BagelModel(**data)
-    assert set(bagel.model_fields.keys()) == {
+    assert set(bagel.model_dump().keys()) == {
         Bagel.col_participant_id,
         Bagel.col_bids_participant_id,
         Bagel.col_session_id,


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes none

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Pydantic now warns when `model_fields` is access from an object/instance instead of a class, which happens in some tests. Fixed by using `model_dump()` instead

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions
