### PR TITLE
[MAINT] Fix dependabot username in `release.yml`

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,7 +2,7 @@ changelog:
   exclude:
     authors:
       - pre-commit-ci
-      - dependabot[bot]
+      - dependabot
       - nipoppy-bot
   categories:
     - title: Breaking Changes


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes none

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- [Previously](https://github.com/nipoppy/nipoppy/blob/591dd2673d3a6d7a7847f783529aecb8d4257495/.github/release.yml#L5) we had `dependabot[bot]` in the list of excluded authors in `.github/release.yml`, which seems to be wrong since the [latest release notes](https://github.com/nipoppy/nipoppy/releases/tag/0.3.4) include PRs from Dependabot

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--580.org.readthedocs.build/en/580/

<!-- readthedocs-preview nipoppy end -->