### PR TITLE
[FIX] Make runners always bind dataset root directory in containers

### DIFF
--- a/nipoppy/workflows/runner.py
+++ b/nipoppy/workflows/runner.py
@@ -70,6 +70,9 @@ class PipelineRunner(BasePipelineWorkflow):
         if bind_paths is None:
             bind_paths = []
 
+        # always bind the dataset's root directory
+        bind_paths = [self.layout.dpath_root] + bind_paths
+
         # get and process container config
         container_config = self.pipeline_step_config.get_container_config()
         container_config = ContainerConfig(

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -222,12 +222,17 @@ def test_process_container_config(config: Config, tmp_path: Path):
 
     runner.config = config
 
-    result = runner.process_container_config(participant_id="01", session_id="BL")
+    bind_path = tmp_path / "to_bind"
+    result = runner.process_container_config(
+        participant_id="01", session_id="BL", bind_paths=[bind_path]
+    )
 
     # check that the subcommand 'exec' from the Boutiques container config is used
     # note: the container command in the config is "echo" because otherwise the
     # check for the container command fails if Singularity/Apptainer is not on the PATH
     assert result.startswith("echo exec")
+    assert f"--bind {runner.layout.dpath_root.resolve()} " in result
+    assert result.endswith(f"--bind {bind_path.resolve()}")
 
     # check that the right container config was used
     assert "--flag1" in result


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #577

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- 

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions
