### PR TITLE
[BUG] delete --regenerate flag from rich_click.OPTION_GROUPS

### DIFF
--- a/nipoppy/cli.py
+++ b/nipoppy/cli.py
@@ -36,6 +36,60 @@ def handle_exception(workflow):
     finally:
         sys.exit(workflow.return_code)
 
+click.rich_click.OPTION_GROUPS = {
+    "nipoppy *": [
+        {
+            "name": "Command-specific",
+            "options": [
+                "--dataset",
+                "--pipeline",
+                "--pipeline-version",
+                "--pipeline-step",
+                "--bids-source",
+                "--mode",
+                "--empty",
+                "--copy-files",
+                "--check-dicoms",
+                "--tar",
+                "--query",
+                "--size",
+                "--zenodo-token",
+                "--sandbox",
+                "--force",
+            ],
+        },
+        {
+            "name": "Filtering",
+            "options": [
+                "--participant-id",
+                "--session-id",
+            ],
+        },
+        {
+            "name": "Parallelization",
+            "options": [
+                "--hpc",
+                "--write-list",
+            ],
+        },
+        {
+            "name": "Troubleshooting",
+            "options": [
+                "--verbose",
+                "--dry-run",
+                "--simulate",
+                "--keep-workdir",
+            ],
+        },
+        {
+            "name": "Miscellaneous",
+            "options": [
+                "--layout",
+                "--help",
+            ],
+        },
+    ]
+}
 
 def dataset_option(func):
     """Define dataset options for the CLI.
@@ -171,62 +225,6 @@ class OrderedGroup(click.RichGroup):
     def list_commands(self, ctx):
         """List commands in the order they were added."""
         return list(self.commands.keys())
-
-
-click.rich_click.OPTION_GROUPS = {
-    "nipoppy *": [
-        {
-            "name": "Command-specific",
-            "options": [
-                "--dataset",
-                "--pipeline",
-                "--pipeline-version",
-                "--pipeline-step",
-                "--bids-source",
-                "--mode",
-                "--empty",
-                "--copy-files",
-                "--check-dicoms",
-                "--tar",
-                "--query",
-                "--size",
-                "--zenodo-token",
-                "--sandbox",
-                "--force",
-            ],
-        },
-        {
-            "name": "Filtering",
-            "options": [
-                "--participant-id",
-                "--session-id",
-            ],
-        },
-        {
-            "name": "Parallelization",
-            "options": [
-                "--hpc",
-                "--write-list",
-            ],
-        },
-        {
-            "name": "Troubleshooting",
-            "options": [
-                "--verbose",
-                "--dry-run",
-                "--simulate",
-                "--keep-workdir",
-            ],
-        },
-        {
-            "name": "Miscellaneous",
-            "options": [
-                "--layout",
-                "--help",
-            ],
-        },
-    ]
-}
 
 
 @click.group(

--- a/nipoppy/cli.py
+++ b/nipoppy/cli.py
@@ -185,7 +185,6 @@ click.rich_click.OPTION_GROUPS = {
                 "--bids-source",
                 "--mode",
                 "--empty",
-                "--regenerate",
                 "--copy-files",
                 "--check-dicoms",
                 "--tar",

--- a/nipoppy/cli.py
+++ b/nipoppy/cli.py
@@ -36,6 +36,7 @@ def handle_exception(workflow):
     finally:
         sys.exit(workflow.return_code)
 
+
 click.rich_click.OPTION_GROUPS = {
     "nipoppy *": [
         {
@@ -90,6 +91,7 @@ click.rich_click.OPTION_GROUPS = {
         },
     ]
 }
+
 
 def dataset_option(func):
     """Define dataset options for the CLI.


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #607 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- delete --regenerate flag from rich_click.OPTION_GROUPS in order to show `--regenerate, --force` not twice when running `nipoppy track-curation -h`

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--609.org.readthedocs.build/en/609/

<!-- readthedocs-preview nipoppy end -->