### PR TITLE
[ENH] Do not log subprocess outputs that have `\r` in them

### DIFF
--- a/nipoppy/workflows/base.py
+++ b/nipoppy/workflows/base.py
@@ -106,6 +106,9 @@ class BaseWorkflow(Base, ABC):
         def process_output(output_source, log_prefix: str, log_level=logging.INFO):
             """Consume lines from an IO stream and log them."""
             for line in output_source:
+                line = line.decode()
+                if "\r" in line:
+                    continue
                 line = line.strip("\n")
                 # using extra={"markup": False} in case the output contains substrings
                 # that would be interpreted as closing tags by the RichHandler
@@ -135,7 +138,6 @@ class BaseWorkflow(Base, ABC):
                 command_or_args,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                text=True,
                 **kwargs,
             )
 

--- a/tests/test_workflow_base.py
+++ b/tests/test_workflow_base.py
@@ -98,9 +98,18 @@ def test_run_command_no_markup(
 
 
 def test_run_command_quiet(workflow: BaseWorkflow, caplog: pytest.LogCaptureFixture):
-    message = "This should be printed"
+    message = "test"
     workflow.run_command(["echo", message], quiet=True)
     assert workflow.log_prefix_run not in caplog.text
+    assert message in caplog.text
+
+
+def test_run_command_no_carriage_return(
+    workflow: BaseWorkflow, caplog: pytest.LogCaptureFixture
+):
+    message = "test"
+    workflow.run_command(["python", "-c", f'print("{message}\\r")'])
+    assert workflow.log_prefix_run_stdout not in caplog.text
     assert message in caplog.text
 
 


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #539

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- This is my workaround to avoid logging process bars, which are not that informative and can greatly bloat log files. Tested locally and it seems like it works for `tqdm` progress bars, but it would be good to test with e.g. @bcmcpher's freewater extraction pipeline
- Note: I also tested locally with [progress bars generated with `rich`](https://rich.readthedocs.io/en/stable/progress.html) and, interestingly, in those cases the progress still get written but only in 1 line (at least in my test). But `rich` is doing some fancy things with their progress bars because they can make them stay at the bottom of the terminal even if other things are printed in the meantime (!)

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--625.org.readthedocs.build/en/625/

<!-- readthedocs-preview nipoppy end -->