### PR TITLE
[ENH]: allow forced dataset init on non-empty dirs

### DIFF
--- a/nipoppy/cli.py
+++ b/nipoppy/cli.py
@@ -320,6 +320,14 @@ def cli():
     help=("Path to a BIDS dataset to initialize the layout with."),
 )
 @click.option(
+    "--force",
+    is_flag=True,
+    help=(
+        "Create a nipoppy dataset even if there are already files present."
+        " (May clobber existing files.)"
+    ),
+)
+@click.option(
     "--mode",
     type=click.Choice(["copy", "move", "symlink"]),
     default="symlink",

--- a/nipoppy/cli.py
+++ b/nipoppy/cli.py
@@ -321,6 +321,7 @@ def cli():
 )
 @click.option(
     "--force",
+    "-f",
     is_flag=True,
     help=(
         "Create a nipoppy dataset even if there are already files present."

--- a/nipoppy/workflows/base.py
+++ b/nipoppy/workflows/base.py
@@ -264,6 +264,18 @@ class BaseWorkflow(Base, ABC):
         if not self.dry_run:
             shutil.rmtree(path, **kwargs_to_use)
 
+    def _remove_existing(self, path, log_level=logging.INFO):
+        """Remove existing file, directory, or symlink without ignoring errors."""
+        self.logger.log(level=log_level, msg=f"Removing existing {path}")
+        if not self.dry_run:
+            path_obj = Path(path)
+            if path_obj.is_symlink():
+                path_obj.unlink()
+            elif path_obj.is_dir():
+                shutil.rmtree(path)
+            else:
+                path_obj.unlink()
+
 
 class BaseDatasetWorkflow(BaseWorkflow, ABC):
     """Base workflow class with awareness of dataset layout and components."""

--- a/nipoppy/workflows/dataset_init.py
+++ b/nipoppy/workflows/dataset_init.py
@@ -80,7 +80,9 @@ class InitWorkflow(BaseDatasetWorkflow):
                         f"{msg} `--force` specified, proceeding anyway."
                     )
                 else:
-                    raise FileExistsError(msg)
+                    raise FileExistsError(
+                        f"{msg}, if this is intended consider using the --force flag."
+                    )
 
         # create directories
         self.mkdir(self.dpath_root / NIPOPPY_DIR_NAME)

--- a/nipoppy/workflows/dataset_init.py
+++ b/nipoppy/workflows/dataset_init.py
@@ -85,6 +85,8 @@ class InitWorkflow(BaseDatasetWorkflow):
         # create directories
         self.mkdir(self.dpath_root / NIPOPPY_DIR_NAME)
         for dpath in self.layout.get_paths(directory=True, include_optional=True):
+            if dpath.exists() and self.force:
+                self._remove_existing(dpath)
             # If a bids_source is passed it means datalad is installed.
             if self.bids_source is not None and dpath.stem == "bids":
                 if self.mode == "copy":

--- a/nipoppy/workflows/dataset_init.py
+++ b/nipoppy/workflows/dataset_init.py
@@ -85,9 +85,6 @@ class InitWorkflow(BaseDatasetWorkflow):
         # create directories
         self.mkdir(self.dpath_root / NIPOPPY_DIR_NAME)
         for dpath in self.layout.get_paths(directory=True, include_optional=True):
-            if dpath.exists() and self.force:
-                self._remove_existing(dpath, log_level=logging.DEBUG)
-
             if self.bids_source is not None and dpath == self.layout.dpath_bids:
                 self.handle_bids_source()
             else:
@@ -137,6 +134,8 @@ class InitWorkflow(BaseDatasetWorkflow):
         dpath = self.layout.dpath_bids
 
         # Handle edge case where we need to clobber existing data
+        if dpath.exists() and self.force:
+            self._remove_existing(dpath, log_level=logging.DEBUG)
 
         if self.mode == "copy":
             self.copytree(self.bids_source, str(dpath), log_level=logging.DEBUG)

--- a/nipoppy/workflows/dataset_init.py
+++ b/nipoppy/workflows/dataset_init.py
@@ -35,6 +35,7 @@ class InitWorkflow(BaseDatasetWorkflow):
         dpath_root: Path,
         bids_source=None,
         mode="symlink",
+        force=False,
         fpath_layout: Optional[StrOrPathLike] = None,
         verbose: bool = False,
         dry_run: bool = False,
@@ -52,6 +53,7 @@ class InitWorkflow(BaseDatasetWorkflow):
         self.fname_readme = "README.md"
         self.bids_source = bids_source
         self.mode = mode
+        self.force = force
 
     def run_main(self):
         """Create dataset directory structure.
@@ -72,9 +74,13 @@ class InitWorkflow(BaseDatasetWorkflow):
                 raise FileExistsError(f"Dataset is an existing file: {self.dpath_root}")
 
             if len(filenames) > 0:
-                raise FileExistsError(
-                    f"Dataset directory is non-empty: {self.dpath_root}"
-                )
+                msg = f"Dataset directory is non-empty: {self.dpath_root}"
+                if self.force:
+                    self.logger.warning(
+                        f"{msg} `--force` specified, proceeding anyway."
+                    )
+                else:
+                    raise FileExistsError(msg)
 
         # create directories
         self.mkdir(self.dpath_root / NIPOPPY_DIR_NAME)

--- a/tests/test_workflow_init.py
+++ b/tests/test_workflow_init.py
@@ -83,6 +83,14 @@ def test_non_empty_dir(dpath_root: Path):
         workflow.run()
 
 
+def test_non_empty_dir_forced(dpath_root: Path):
+    dpath_root.mkdir(parents=True)
+    dpath_root.joinpath("unexepected_file").touch()
+
+    workflow = InitWorkflow(dpath_root=dpath_root, force=True)
+    workflow.run()
+
+
 def test_is_file(dpath_root: Path):
     dpath_root.touch()
 


### PR DESCRIPTION
This PR adds `--force` flag option to the init command. 

This is useful for dirs that are already under version control and have .git or .datalad dirs.

Fixes https://github.com/nipoppy/nipoppy/issues/520

### TODO fix Collision behavior (should be discussed before merge)

What should the expected behavior be when there are existing files that will collide?
[In this comment](https://github.com/nipoppy/nipoppy/issues/520#issuecomment-3058127939) and in the helptext I added, we would clobber those files, which seems reasonable to me. 

This seems to be the case for all files except for the bids source.  When I run the init --force command twice, I would expect to clobber all files, but instead there is a problem with the bids source files.  
`FileExistsError: [Errno 17] File exists: '/home/austin/devel/sandbox/ds004101' -> '/tmp/nipoppy-force-test/bids'` 

I get this same error in symlink mode and copy mode, move mode hits a permissions error due to the source data being a datalad dataset. 

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--682.org.readthedocs.build/en/682/

<!-- readthedocs-preview nipoppy end -->