### PR TITLE
[ENH] Let `bosh` handle container launching

### DIFF
--- a/nipoppy/config/container.py
+++ b/nipoppy/config/container.py
@@ -10,7 +10,7 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from nipoppy.env import StrOrPathLike
+from nipoppy.env import ContainerCommandEnum, StrOrPathLike
 from nipoppy.logger import get_logger
 
 # Apptainer
@@ -26,9 +26,12 @@ class ContainerConfig(BaseModel):
     Does not include information about the container image.
     """
 
-    COMMAND: str = Field(
-        default="apptainer",
-        description="Name of or path to Apptainer/Singularity executable",
+    COMMAND: Optional[ContainerCommandEnum] = Field(
+        default=ContainerCommandEnum.APPTAINER,
+        description=(
+            "Name of container engine. If null/None, the pipeline will not run in a "
+            "container (for e.g., baremetal installations or NeuroDesk)."
+        ),
     )
     ARGS: list[str] = Field(
         default=[],

--- a/nipoppy/config/container.py
+++ b/nipoppy/config/container.py
@@ -30,7 +30,7 @@ class ContainerConfig(BaseModel):
         default=ContainerCommandEnum.APPTAINER,
         description=(
             "Name of container engine. If null/None, the pipeline will not run in a "
-            "container (for e.g., baremetal installations or NeuroDesk)."
+            "container (e.g., baremetal installations)."
         ),
     )
     ARGS: list[str] = Field(

--- a/nipoppy/config/container.py
+++ b/nipoppy/config/container.py
@@ -292,7 +292,7 @@ def prepare_container(
     str
         The command string
     """
-    command = container_config.COMMAND
+    command = container_config.COMMAND.value
     args = container_config.ARGS
     env_vars = container_config.ENV_VARS
 

--- a/nipoppy/config/container.py
+++ b/nipoppy/config/container.py
@@ -292,6 +292,9 @@ def prepare_container(
     str
         The command string
     """
+    if container_config.COMMAND is None:
+        raise ValueError("COMMAND cannot be None in container config")
+
     command = container_config.COMMAND.value
     args = container_config.ARGS
     env_vars = container_config.ENV_VARS

--- a/nipoppy/env.py
+++ b/nipoppy/env.py
@@ -29,6 +29,13 @@ EXT_TAR = ".tar"
 EXT_LOG = ".log"
 
 
+class ContainerCommandEnum(str, Enum):
+    """Container commands."""
+
+    SINGULARITY = "singularity"
+    APPTAINER = "apptainer"
+
+
 class PipelineTypeEnum(str, Enum):
     """Pipeline types."""
 

--- a/nipoppy/workflows/bids_conversion.py
+++ b/nipoppy/workflows/bids_conversion.py
@@ -124,7 +124,7 @@ class BidsConversionRunner(PipelineRunner):
     def run_single(self, participant_id: str, session_id: str):
         """Run BIDS conversion on a single participant/session."""
         # get container command
-        container_command = self.process_container_config(
+        container_command, container_config = self.process_container_config(
             participant_id=participant_id,
             session_id=session_id,
             bind_paths=[
@@ -135,7 +135,10 @@ class BidsConversionRunner(PipelineRunner):
 
         # run pipeline with Boutiques
         invocation_and_descriptor = self.launch_boutiques_run(
-            participant_id, session_id, container_command=container_command
+            participant_id,
+            session_id,
+            container_args=container_config.ARGS,
+            container_command=container_command,
         )
 
         # update status

--- a/nipoppy/workflows/bids_conversion.py
+++ b/nipoppy/workflows/bids_conversion.py
@@ -124,21 +124,24 @@ class BidsConversionRunner(PipelineRunner):
     def run_single(self, participant_id: str, session_id: str):
         """Run BIDS conversion on a single participant/session."""
         # get container command
-        container_command, container_config = self.process_container_config(
-            participant_id=participant_id,
-            session_id=session_id,
-            bind_paths=[
-                self.layout.dpath_post_reorg,
-                self.layout.dpath_bids,
-            ],
-        )
+        launch_boutiques_run_kwargs = {}
+        if self.config.CONTAINER_CONFIG.COMMAND is not None:
+            container_command, container_config = self.process_container_config(
+                participant_id=participant_id,
+                session_id=session_id,
+                bind_paths=[
+                    self.layout.dpath_post_reorg,
+                    self.layout.dpath_bids,
+                ],
+            )
+            launch_boutiques_run_kwargs["container_command"] = container_command
+            launch_boutiques_run_kwargs["container_config"] = container_config
 
         # run pipeline with Boutiques
         invocation_and_descriptor = self.launch_boutiques_run(
             participant_id,
             session_id,
-            container_args=container_config.ARGS,
-            container_command=container_command,
+            **launch_boutiques_run_kwargs,
         )
 
         # update status

--- a/nipoppy/workflows/extractor.py
+++ b/nipoppy/workflows/extractor.py
@@ -175,7 +175,7 @@ class ExtractionRunner(PipelineRunner):
     def run_single(self, participant_id: str, session_id: str):
         """Run extractor on a single participant/session."""
         # get container command
-        container_command = self.process_container_config(
+        container_command, container_config = self.process_container_config(
             participant_id=participant_id,
             session_id=session_id,
             bind_paths=[
@@ -186,7 +186,10 @@ class ExtractionRunner(PipelineRunner):
 
         # run pipeline with Boutiques
         invocation_and_descriptor = self.launch_boutiques_run(
-            participant_id, session_id, container_command=container_command
+            participant_id,
+            session_id,
+            container_args=container_config.ARGS,
+            container_command=container_command,
         )
 
         return invocation_and_descriptor

--- a/nipoppy/workflows/extractor.py
+++ b/nipoppy/workflows/extractor.py
@@ -175,21 +175,24 @@ class ExtractionRunner(PipelineRunner):
     def run_single(self, participant_id: str, session_id: str):
         """Run extractor on a single participant/session."""
         # get container command
-        container_command, container_config = self.process_container_config(
-            participant_id=participant_id,
-            session_id=session_id,
-            bind_paths=[
-                self.dpath_pipeline_idp,
-                self.dpath_pipeline_output,
-            ],
-        )
+        launch_boutiques_run_kwargs = {}
+        if self.config.CONTAINER_CONFIG.COMMAND is not None:
+            container_command, container_config = self.process_container_config(
+                participant_id=participant_id,
+                session_id=session_id,
+                bind_paths=[
+                    self.dpath_pipeline_idp,
+                    self.dpath_pipeline_output,
+                ],
+            )
+            launch_boutiques_run_kwargs["container_command"] = container_command
+            launch_boutiques_run_kwargs["container_config"] = container_config
 
         # run pipeline with Boutiques
         invocation_and_descriptor = self.launch_boutiques_run(
             participant_id,
             session_id,
-            container_args=container_config.ARGS,
-            container_command=container_command,
+            **launch_boutiques_run_kwargs,
         )
 
         return invocation_and_descriptor

--- a/nipoppy/workflows/pipeline.py
+++ b/nipoppy/workflows/pipeline.py
@@ -262,8 +262,8 @@ class BasePipelineWorkflow(BaseDatasetWorkflow, ABC):
                 error_message += (
                     ". This file can be downloaded to the appropriate path by running "
                     "the following command:"
-                    f"\n\n{self.pipeline_step_config.CONTAINER_CONFIG.COMMAND} pull "
-                    f"{self.pipeline_config.CONTAINER_INFO.FILE} "
+                    f"\n\n{self.pipeline_step_config.CONTAINER_CONFIG.COMMAND.value} "
+                    f"pull {self.pipeline_config.CONTAINER_INFO.FILE} "
                     f"{self.pipeline_config.CONTAINER_INFO.URI}"
                 )
             raise FileNotFoundError(error_message)

--- a/nipoppy/workflows/pipeline_store/install.py
+++ b/nipoppy/workflows/pipeline_store/install.py
@@ -141,7 +141,7 @@ class PipelineInstallWorkflow(BaseDatasetWorkflow):
                 ):
                     self.run_command(
                         [
-                            self.config.CONTAINER_CONFIG.COMMAND,
+                            self.config.CONTAINER_CONFIG.COMMAND.value,
                             "pull",
                             fpath_container,
                             pipeline_config.CONTAINER_INFO.URI,

--- a/nipoppy/workflows/runner.py
+++ b/nipoppy/workflows/runner.py
@@ -144,7 +144,10 @@ class PipelineRunner(BasePipelineWorkflow):
             )
         else:
             descriptor_str = json.dumps(self.descriptor)
-            if container_config is None:
+            if (
+                container_config is None
+                or self.descriptor.get("container-image") is None
+            ):
                 bosh_exec_launch_args.append("--no-container")
             else:
                 bosh_exec_launch_args.extend(

--- a/nipoppy/workflows/runner.py
+++ b/nipoppy/workflows/runner.py
@@ -130,6 +130,9 @@ class PipelineRunner(BasePipelineWorkflow):
         """Launch a pipeline run using Boutiques."""
         bosh_exec_launch_args = []
 
+        if self.verbose:
+            bosh_exec_launch_args.append("--debug")
+
         # process the descriptor if it containers Nipoppy-specific placeholder
         # expressions (legacy behaviour)
         if TEMPLATE_REPLACE_PATTERN.search(self.descriptor["command-line"]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Topic :: Software Development",
 ]
 dependencies = [
-    "boutiques>0.5.28",
+    "boutiques>0.5.30",
     "click",
     "httpx",
     "jinja2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Topic :: Software Development",
 ]
 dependencies = [
-    "boutiques>0.5.30",
+    "boutiques>=0.5.30",
     "click",
     "httpx",
     "jinja2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Topic :: Software Development",
 ]
 dependencies = [
-    "boutiques",
+    "boutiques>0.5.28",
     "click",
     "httpx",
     "jinja2",

--- a/tests/test_config_container.py
+++ b/tests/test_config_container.py
@@ -270,6 +270,11 @@ def test_prepare_container(data, expected):
     assert prepare_container(ContainerConfig(**data), check=False) == expected
 
 
+def test_prepare_container_error():
+    with pytest.raises(ValueError, match="COMMAND cannot be None"):
+        prepare_container(ContainerConfig(COMMAND=None), check=False)
+
+
 @pytest.mark.parametrize(
     "env_vars",
     [

--- a/tests/test_config_container.py
+++ b/tests/test_config_container.py
@@ -259,10 +259,10 @@ def test_check_container_command_error(command):
         ({}, "apptainer run"),
         (
             {
-                "COMMAND": "/path/to/singularity",
+                "COMMAND": "singularity",
                 "ARGS": ["--cleanenv"],
             },
-            "/path/to/singularity run --cleanenv",
+            "singularity run --cleanenv",
         ),
     ],
 )

--- a/tests/test_workflow_bids_conversion.py
+++ b/tests/test_workflow_bids_conversion.py
@@ -101,7 +101,10 @@ def test_run_single(
     workflow.pipeline_step_config.UPDATE_STATUS = update_status
 
     mocked_process_container_config = mocker.patch.object(
-        workflow, "process_container_config"
+        workflow,
+        "process_container_config",
+        # usually returns string and config object
+        return_value=(None, mocker.MagicMock()),
     )
     mocked_launch_boutiques_run = mocker.patch.object(workflow, "launch_boutiques_run")
 

--- a/tests/test_workflow_extractor.py
+++ b/tests/test_workflow_extractor.py
@@ -254,7 +254,9 @@ def test_run_single(
 ):
 
     mocked_process_container_config = mocker.patch(
-        "nipoppy.workflows.runner.PipelineRunner.process_container_config"
+        "nipoppy.workflows.runner.PipelineRunner.process_container_config",
+        # usually returns string and config object
+        return_value=(None, mocker.MagicMock()),
     )
     mocked_launch_boutiques_container = mocker.patch(
         "nipoppy.workflows.runner.PipelineRunner.launch_boutiques_run"

--- a/tests/test_workflow_pipeline_store_install.py
+++ b/tests/test_workflow_pipeline_store_install.py
@@ -10,7 +10,12 @@ import pytest_mock
 
 from nipoppy.config.main import Config
 from nipoppy.config.pipeline import ProcPipelineConfig
-from nipoppy.env import CURRENT_SCHEMA_VERSION, PipelineTypeEnum, ReturnCode
+from nipoppy.env import (
+    CURRENT_SCHEMA_VERSION,
+    ContainerCommandEnum,
+    PipelineTypeEnum,
+    ReturnCode,
+)
 from nipoppy.layout import DatasetLayout
 from nipoppy.workflows.pipeline_store.install import PipelineInstallWorkflow
 from nipoppy.zenodo_api import ZenodoAPI
@@ -185,6 +190,8 @@ def test_download_container(
             "fake_uri",
         ]
     )
+    # first call, positional arg list, first element
+    assert not isinstance(mocked.call_args[0][0][0], ContainerCommandEnum)
 
 
 @pytest.mark.parametrize("confirm_download", [True, False])

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -82,6 +82,10 @@ def runner(tmp_path: Path, mocker: pytest_mock.MockFixture) -> PipelineRunner:
         "description": "A dummy pipeline for testing",
         "schema-version": "0.5",
         "command-line": "echo [ARG1] [ARG2] [[NIPOPPY_DPATH_BIDS]]",
+        "container-image": {
+            "image": "dummy/image",
+            "type": "docker",
+        },
         "inputs": [
             {
                 "id": "arg1",
@@ -216,6 +220,28 @@ def test_launch_boutiques_run_bosh_container_opts(
 
     else:
         assert "Additional launch options:" in caplog.text
+
+
+def test_launch_boutiques_run_bosh_no_container_image(
+    runner: PipelineRunner,
+    mocker: pytest_mock.MockFixture,
+):
+    runner.descriptor["command-line"] = "echo [ARG1] [ARG2]"
+    runner.descriptor.pop("container-image")
+
+    participant_id = "01"
+    session_id = "BL"
+
+    mocked_run_command = mocker.patch.object(runner, "run_command")
+
+    runner.launch_boutiques_run(
+        participant_id,
+        session_id,
+        container_config=ContainerConfig(),
+    )
+
+    container_opts = mocked_run_command.call_args[0][0]  # first positional argument
+    assert "--no-container" in container_opts
 
 
 @pytest.mark.parametrize("simulate", [True, False])

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -189,15 +189,18 @@ def test_launch_boutiques_run(
     ],
 )
 @pytest.mark.parametrize("simulate", [True, False])
+@pytest.mark.parametrize("verbose", [True, False])
 def test_launch_boutiques_run_bosh_container_opts(
     container_config,
     expected_container_opts,
     simulate,
+    verbose,
     runner: PipelineRunner,
     mocker: pytest_mock.MockFixture,
     caplog: pytest.LogCaptureFixture,
 ):
     runner.simulate = simulate
+    runner.verbose = verbose
     runner.descriptor["command-line"] = "echo [ARG1] [ARG2]"
 
     participant_id = "01"
@@ -212,14 +215,19 @@ def test_launch_boutiques_run_bosh_container_opts(
     )
 
     if not simulate:
-        container_opts = mocked_run_command.call_args[0][0]  # first positional argument
+        # first positional argument
+        bosh_command_args = mocked_run_command.call_args[0][0]
+
         for opt in expected_container_opts:
             assert (
-                opt in container_opts
-            ), f"Expected container option '{opt}' not found in {container_opts}"
+                opt in bosh_command_args
+            ), f"Expected container option '{opt}' not found in {bosh_command_args}"
+
+        assert ("--debug" in bosh_command_args) == verbose
 
     else:
         assert "Additional launch options:" in caplog.text
+        assert ("--debug" in caplog.text) == verbose
 
 
 def test_launch_boutiques_run_bosh_no_container_image(

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -63,7 +63,7 @@ def runner(tmp_path: Path, mocker: pytest_mock.MockFixture) -> PipelineRunner:
                 "CONTAINER_CONFIG": {"ARGS": ["--flag2"]},
                 "CONTAINER_INFO": {
                     "FILE": str(fpath_container),
-                    "URI": "docker://org/name:1.0.0",
+                    "URI": "docker://dummy/image:1.0.0",
                 },
                 "STEPS": [
                     {
@@ -665,6 +665,9 @@ def test_run_single_pybids_db(
 
     # Mock the set_up_bids_db method
     mocked_set_up_bids_db = mocker.patch.object(runner, "set_up_bids_db")
+
+    # Mock launch_boutiques_run to avoid issues with bosh trying to launch Docker
+    mocker.patch.object(runner, "launch_boutiques_run")
 
     # Call run_single
     runner.run_single(participant_id=participant_id, session_id=session_id)


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #239

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Let `bosh` handle container launching instead of having Nipoppy inject container-specific things in the Boutiques descriptor
- Maintain backward compatibility:
   - If the descriptor's `command-line` does contains `[[NIPOPPY_...]]`, maintain legacy behaviour
   - Otherwise, pass the container image path and any container options through the `--imagepath` and `--container-opts` options for `bosh exec launch`
      - In the global config, if `CONTAINER_CONFIG.COMMAND` is `None`, pass `--no-container` to `bosh exec launch`

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--686.org.readthedocs.build/en/686/

<!-- readthedocs-preview nipoppy end -->