### PR TITLE
[BUG] Exit with non-zero code if no participants/sessions were found when running a pipeline

### DIFF
--- a/nipoppy/env.py
+++ b/nipoppy/env.py
@@ -43,6 +43,7 @@ class ReturnCode:
     SUCCESS = 0
     UNKNOWN_FAILURE = 1
     PARTIAL_SUCCESS = 64
+    NO_PARTICIPANTS_OR_SESSIONS_TO_RUN = 65
 
 
 class LogColor:

--- a/nipoppy/workflows/pipeline.py
+++ b/nipoppy/workflows/pipeline.py
@@ -746,11 +746,12 @@ class BasePipelineWorkflow(BaseDatasetWorkflow, ABC):
     def run_cleanup(self):
         """Log a summary message."""
         if self.n_total == 0:
-            self.logger.warning(
+            self.logger.error(
                 "No participants or sessions to run. Make sure there are no mistakes "
                 "in the input arguments, the dataset's manifest or config file, and/or "
                 f"check the curation status file at {self.layout.fpath_curation_status}"
             )
+            self.return_code = ReturnCode.NO_PARTICIPANTS_OR_SESSIONS_TO_RUN
         elif self.hpc is not None:
             if self.n_success == 0:
                 self.logger.error(f"[{LogColor.FAILURE}]Failed to submit HPC jobs[/]")

--- a/nipoppy/workflows/pipeline.py
+++ b/nipoppy/workflows/pipeline.py
@@ -746,7 +746,7 @@ class BasePipelineWorkflow(BaseDatasetWorkflow, ABC):
     def run_cleanup(self):
         """Log a summary message."""
         if self.n_total == 0:
-            self.logger.error(
+            self.logger.warning(
                 "No participants or sessions to run. Make sure there are no mistakes "
                 "in the input arguments, the dataset's manifest or config file, and/or "
                 f"check the curation status file at {self.layout.fpath_curation_status}"

--- a/tests/test_workflow_pipeline.py
+++ b/tests/test_workflow_pipeline.py
@@ -1013,14 +1013,14 @@ def test_run_cleanup(
     assert expected_message.format(n_success, n_total) in caplog.text
 
 
-def test_run_cleanup_no_participants_error(
+def test_run_cleanup_no_participants_warning(
     workflow: PipelineWorkflow, caplog: pytest.LogCaptureFixture
 ):
     workflow.n_success = 0
     workflow.n_total = 0
     workflow.run_cleanup()
     assert any(
-        record.levelname == "ERROR"
+        record.levelname == "WARNING"
         and "No participants or sessions to run" in record.message
         for record in caplog.records
     ), "Wrong log message or level"

--- a/tests/test_workflow_pipeline.py
+++ b/tests/test_workflow_pipeline.py
@@ -1013,6 +1013,22 @@ def test_run_cleanup(
     assert expected_message.format(n_success, n_total) in caplog.text
 
 
+def test_run_cleanup_no_participants_error(
+    workflow: PipelineWorkflow, caplog: pytest.LogCaptureFixture
+):
+    workflow.n_success = 0
+    workflow.n_total = 0
+    workflow.run_cleanup()
+    assert any(
+        record.levelname == "ERROR"
+        and "No participants or sessions to run" in record.message
+        for record in caplog.records
+    ), "Wrong log message or level"
+    assert (
+        workflow.return_code == ReturnCode.NO_PARTICIPANTS_OR_SESSIONS_TO_RUN
+    ), "Wrong return code"
+
+
 @pytest.mark.parametrize(
     "n_success,n_total,expected_message",
     [


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #600

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Change log level from warning to error
- Return non-zero exit code

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--690.org.readthedocs.build/en/690/

<!-- readthedocs-preview nipoppy end -->