### PR TITLE
[ENH] Add `joblib` parallelization to `nipoppy track-processing`

### DIFF
--- a/nipoppy/cli/cli.py
+++ b/nipoppy/cli/cli.py
@@ -66,6 +66,7 @@ click.rich_click.OPTION_GROUPS = {
             "options": [
                 "--hpc",
                 "--write-list",
+                "--n-jobs",
             ],
         },
         {
@@ -245,6 +246,13 @@ def process(**params):
 @cli.command()
 @dataset_option
 @pipeline_options
+@click.option(
+    "--n-jobs",
+    type=int,
+    default=1,
+    show_default=True,
+    help=("Number of parallel workers to use."),
+)
 @global_options
 @layout_option
 def track_processing(**params):

--- a/nipoppy/layout.py
+++ b/nipoppy/layout.py
@@ -2,7 +2,7 @@
 
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Optional, Tuple
+from typing import Optional, Tuple
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -186,44 +186,63 @@ class DatasetLayout(Base):
         self.dpath_nipoppy = self.dpath_root / NIPOPPY_DIR_NAME
 
         # directories (for type hinting)
-        self.dpath_bids: Path
-        self.dpath_derivatives: Path
-        self.dpath_sourcedata: Path
-        self.dpath_src_tabular: Path
-        self.dpath_src_imaging: Path
-        self.dpath_downloads: Path
-        self.dpath_pre_reorg: Path
-        self.dpath_post_reorg: Path
-        self.dpath_code: Path
-        self.dpath_hpc: Path
-        self.dpath_pipelines: Path
-        self.dpath_containers: Path
-        self.dpath_scratch: Path
-        self.dpath_work: Path
-        self.dpath_pybids_db: Path
-        self.dpath_logs: Path
-        self.dpath_tabular: Path
-        self.dpath_assessments: Path
+        self.dpath_bids: Path = self.get_full_path(self.config.dpath_bids.path)
+        self.dpath_derivatives: Path = self.get_full_path(
+            self.config.dpath_derivatives.path
+        )
+        self.dpath_sourcedata: Path = self.get_full_path(
+            self.config.dpath_sourcedata.path
+        )
+        self.dpath_src_tabular: Path = self.get_full_path(
+            self.config.dpath_src_tabular.path
+        )
+        self.dpath_src_imaging: Path = self.get_full_path(
+            self.config.dpath_src_imaging.path
+        )
+        self.dpath_downloads: Path = self.get_full_path(
+            self.config.dpath_downloads.path
+        )
+        self.dpath_pre_reorg: Path = self.get_full_path(
+            self.config.dpath_pre_reorg.path
+        )
+        self.dpath_post_reorg: Path = self.get_full_path(
+            self.config.dpath_post_reorg.path
+        )
+        self.dpath_code: Path = self.get_full_path(self.config.dpath_code.path)
+        self.dpath_hpc: Path = self.get_full_path(self.config.dpath_hpc.path)
+        self.dpath_pipelines: Path = self.get_full_path(
+            self.config.dpath_pipelines.path
+        )
+        self.dpath_containers: Path = self.get_full_path(
+            self.config.dpath_containers.path
+        )
+        self.dpath_scratch: Path = self.get_full_path(self.config.dpath_scratch.path)
+        self.dpath_work: Path = self.get_full_path(self.config.dpath_work.path)
+        self.dpath_pybids_db: Path = self.get_full_path(
+            self.config.dpath_pybids_db.path
+        )
+        self.dpath_logs: Path = self.get_full_path(self.config.dpath_logs.path)
+        self.dpath_tabular: Path = self.get_full_path(self.config.dpath_tabular.path)
+        self.dpath_assessments: Path = self.get_full_path(
+            self.config.dpath_assessments.path
+        )
 
         # files (for type hinting)
-        self.fpath_config: Path
-        self.fpath_curation_status: Path
-        self.fpath_manifest: Path
-        self.fpath_processing_status: Path
-        self.fpath_demographics: Path
+        self.fpath_config: Path = self.get_full_path(self.config.fpath_config.path)
+        self.fpath_curation_status: Path = self.get_full_path(
+            self.config.fpath_curation_status.path
+        )
+        self.fpath_manifest: Path = self.get_full_path(self.config.fpath_manifest.path)
+        self.fpath_processing_status: Path = self.get_full_path(
+            self.config.fpath_processing_status.path
+        )
+        self.fpath_demographics: Path = self.get_full_path(
+            self.config.fpath_demographics.path
+        )
 
     def get_full_path(self, path: StrOrPathLike) -> Path:
         """Build a full path from a relative path."""
         return self.dpath_root / path
-
-    def __getattribute__(self, name: str) -> Any:
-        try:
-            return super().__getattribute__(name)
-        except AttributeError as exception:
-            if name in self.config.path_labels:
-                return self.get_full_path(self.config.get_path_info(name).path)
-            else:
-                raise exception
 
     def get_paths(self, directory=True, include_optional=False) -> list[Path]:
         """Return a list of all directory or file paths."""

--- a/nipoppy/workflows/tracker.py
+++ b/nipoppy/workflows/tracker.py
@@ -21,6 +21,7 @@ class PipelineTracker(BasePipelineWorkflow):
         pipeline_step: Optional[str] = None,
         participant_id: str = None,
         session_id: str = None,
+        n_jobs: Optional[int] = 1,
         fpath_layout: Optional[StrOrPathLike] = None,
         verbose: bool = False,
         dry_run: bool = False,
@@ -33,9 +34,11 @@ class PipelineTracker(BasePipelineWorkflow):
             pipeline_step=pipeline_step,
             participant_id=participant_id,
             session_id=session_id,
+            n_jobs=n_jobs,
             fpath_layout=fpath_layout,
             verbose=verbose,
             dry_run=dry_run,
+            _skip_logfile=True,
         )
 
     def run_setup(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "click",
     "httpx",
     "jinja2",
+    "joblib",
     "pandas",
     "pybids!=0.18.0",
     "pydantic",


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #708 (partially)
- Related to #505 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Add `--n-jobs` arg to `nipoppy track-processing`
- Do parallelization with `joblib` (tried with `multiprocessing` but got errors due to functions/objects not being serializable with `pickle`
- Disable logging to file because that does not interact well with parallel processes. I don't think saving the tracking logs to a file is very useful anyway

On a dummy test dataset the tracker ran 2x slower with `--n-jobs 2` compared to `--n-jobs 1`, but on a real dataset there is speedup:
```
Benchmark 1: nipoppy track-processing --pipeline freesurfer --pipeline-version 7.3.2 --session-id NAPBL00 --n-jobs 4
  Time (mean ± σ):     24.946 s ±  0.438 s    [User: 42.825 s, System: 31.700 s]
  Range (min … max):   24.467 s … 25.326 s    3 runs
 
Benchmark 2: nipoppy track-processing --pipeline freesurfer --pipeline-version 7.3.2 --session-id NAPBL00 --n-jobs 1
  Time (mean ± σ):     87.112 s ±  1.669 s    [User: 39.009 s, System: 26.845 s]
  Range (min … max):   85.711 s … 88.959 s    3 runs
 
Summary
  nipoppy track-processing --pipeline freesurfer --pipeline-version 7.3.2 --session-id NAPBL00 --n-jobs 4 ran
    3.49 ± 0.09 times faster than nipoppy track-processing --pipeline freesurfer --pipeline-version 7.3.2 --session-id NAPBL00 --n-jobs 1
```

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions
