### PR TITLE
fix dcm2bids version in examples

### DIFF
--- a/docs/source/overview/quickstart/index.md
+++ b/docs/source/overview/quickstart/index.md
@@ -108,9 +108,9 @@ A newly initialized Nipoppy dataset does not contain any pipeline setups or cont
 ```{code-block} console
 $ nipoppy pipeline search dcm2bids
 ```
-**2.** Copy the Zenodo ID of version 3.2.0 of the pipeline (15428012 at the time of writing) and run:
+**2.** Copy the Zenodo ID of version 3.2.0 of the pipeline (16876754 at the time of writing) and run:
 ```{code-block} console
-$ nipoppy pipeline install 15428012
+$ nipoppy pipeline install 16876754
 ```
 **3.** Choose to install the container as well or not: `y/n`
 

--- a/docs/source/overview/quickstart/index.md
+++ b/docs/source/overview/quickstart/index.md
@@ -108,7 +108,7 @@ A newly initialized Nipoppy dataset does not contain any pipeline setups or cont
 ```{code-block} console
 $ nipoppy pipeline search dcm2bids
 ```
-**2.** Copy the Zenodo ID of version 3.2.0 of the pipeline (16876754 at the time of writing) and run:
+**2.** Copy the Zenodo ID of version 3.2.0 of the pipeline (15428012 at the time of writing) and run:
 ```{code-block} console
 $ nipoppy pipeline install 15428012
 ```
@@ -144,7 +144,7 @@ Usually you would start with running `nipoppy bidsify` with the first `--pipelin
     "PIPELINE_VARIABLES": {
         "BIDSIFICATION": {
             "dcm2bids": {
-                "3.1.0": {
+                "3.2.0": {
                     "DCM2BIDS_CONFIG_FILE": "[[NIPOPPY_DPATH_ROOT]]/code/dcm2bids_config.json"
                 }
             }
@@ -217,7 +217,7 @@ $ mkdir templateflow
     "PIPELINE_VARIABLES": {
         "BIDSIFICATION": {
             "dcm2bids": {
-                "3.1.0": {
+                "3.2.0": {
                     "DCM2BIDS_CONFIG_FILE": "[[NIPOPPY_DPATH_ROOT]]/code/dcm2bids_config.json"
                 }
             }


### PR DESCRIPTION
Changes proposed in this pull request:
The dcm2bids version in the examples sometimes was 3.1.0 but we want 3.2.0

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--739.org.readthedocs.build/en/739/

<!-- readthedocs-preview nipoppy end -->