### PR TITLE
[TST] separate linkcheck into separate job

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,32 @@
+---
+name: Check documentation links
+
+on:
+  pull_request:
+    branches: ['main']
+  schedule:
+    - cron: '0 0 * * 0' # Weekly on Sunday at 00:00 UTC
+  workflow_dispatch:
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+
+    - uses: actions/setup-python@v6
+      with:
+        python-version: "3.11"
+
+    - name: Install package with doc dependencies
+      run: |
+        pip install -U pip
+        pip install .[doc]
+
+    - name: Generate JSON schemas for docs
+      run: |
+        python docs/scripts/pydantic_to_jsonschema.py
+
+    - name: Run linkcheck
+      run: |
+        python -m sphinx -b linkcheck -D linkcheck_timeout=30 docs/source/ docs/_build/linkcheck

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,10 +13,6 @@ build:
   jobs:
     pre_build:
       - python docs/scripts/pydantic_to_jsonschema.py
-    post_build:
-      # check for broken external links
-      # https://docs.readthedocs.com/platform/stable/build-customization.html#perform-a-check-for-broken-links
-      - python -m sphinx -b linkcheck -D linkcheck_timeout=30 docs/source/ $READTHEDOCS_OUTPUT/linkcheck
 
 python:
   install:


### PR DESCRIPTION
This will allow the docs build to succeed, and PR preview to work when there is a broken link (which could be 3rd party failure).

Closes: https://github.com/nipoppy/nipoppy/pull/829
(not sure if automation will close that since its a PR)

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--830.org.readthedocs.build/en/830/

<!-- readthedocs-preview nipoppy end -->