### PR TITLE
Fixing pipeline search size issue

### DIFF
--- a/nipoppy/zenodo_api.py
+++ b/nipoppy/zenodo_api.py
@@ -345,7 +345,8 @@ class ZenodoAPI:
             response.raise_for_status()
         except httpx.HTTPError as e:
             raise ZenodoAPIError(
-                f"Failed to search records. JSON response: {response.json()}"
+                f"Failed to search records. Request: {response.request.url}. "
+                f"JSON response: {response.json()} "
             ) from e
 
         return response.json()["hits"]

--- a/tests/integration/test_search_workflow.py
+++ b/tests/integration/test_search_workflow.py
@@ -1,7 +1,8 @@
 import pytest
 
+from nipoppy.exceptions import ConfigError
 from nipoppy.workflows.pipeline_store.search import PipelineSearchWorkflow
-from nipoppy.zenodo_api import ZenodoAPI, ZenodoAPIError
+from nipoppy.zenodo_api import ZenodoAPI
 
 
 @pytest.fixture
@@ -10,11 +11,14 @@ def zenodo_api() -> ZenodoAPI:
 
 
 @pytest.mark.api
-def test_search_size(zenodo_api: ZenodoAPI):
-    PipelineSearchWorkflow(
-        query="",
-        zenodo_api=zenodo_api,
-    ).run()
+def test_search_size(zenodo_api, mocker):
+    spy = mocker.spy(zenodo_api, "search_records")
+    sizes = [1, 5, 10]
+    for s in sizes:
+        PipelineSearchWorkflow(query="", zenodo_api=zenodo_api, size=s).run()
+        spy.assert_called_with(
+            query="", community_id=None, keywords=["Nipoppy"], size=s
+        )
 
 
 @pytest.mark.api
@@ -22,10 +26,13 @@ def test_search_size_exceeds_max(zenodo_api: ZenodoAPI):
     workflow = PipelineSearchWorkflow(
         query="",
         zenodo_api=zenodo_api,
+        size=PipelineSearchWorkflow._api_search_size + 1,
     )
-    workflow._api_search_size += 1
     with pytest.raises(
-        ZenodoAPIError,
-        match="Failed to search records. JSON response:",
+        ConfigError,
+        match=(
+            r"Provided search size \(\d+\) is larger than allowed by api"
+            f" \\({PipelineSearchWorkflow._api_search_size}\\)"
+        ),
     ):
         workflow.run()

--- a/tests/unit/test_zenodo_api.py
+++ b/tests/unit/test_zenodo_api.py
@@ -745,7 +745,7 @@ def test_search_records_status_raised(
     )
     with pytest.raises(
         ZenodoAPIError,
-        match="Failed to search records. JSON response:",
+        match="Failed to search records. Request: .*. JSON response:",
     ):
         zenodo_api.search_records(query=query, size=size)
 

--- a/tests/unit/workflows/pipeline_store/test_search.py
+++ b/tests/unit/workflows/pipeline_store/test_search.py
@@ -130,7 +130,7 @@ def test_run_main(
     workflow.zenodo_api.search_records.assert_called_once_with(
         query=workflow.query,
         keywords=["Nipoppy"],
-        size=workflow._api_search_size,
+        size=1,
         community_id=ZENODO_COMMUNITY_ID if community else None,
     )
     mocked_hits_to_df.assert_called_once_with(hits)


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #839 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- `PipelineSearchWorkflow` now uses `this.size` when calling `ZenodoApi.search_results`
- `PipelineSearchWorkflow.run_main` verifies that `this.size` is within `_api_search_size`. If not, yields nice cli error using `ConfigError`
- `ZenodoApi.search_results` provides information on the http request if the request fails
- Integration test `test_search_workflow` was updated to reflect the new Nipoppy `ConfigError` (instead of ZenodoApi error)
- Integration test `test_search_workflow` now tests that the size parameter is actually used by `PipelineSearchWorkflow`

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--840.org.readthedocs.build/en/840/

<!-- readthedocs-preview nipoppy end -->