### PR TITLE
[MAINT][BUG] Fix tests that fail with `pandas` 3.0.0

### DIFF
--- a/nipoppy/tabular/base.py
+++ b/nipoppy/tabular/base.py
@@ -124,6 +124,7 @@ class BaseTabular(pd.DataFrame, ABC):
         if self.empty and len(self.columns) == 0:
             for col in self.model.model_fields.keys():
                 self[col] = None
+                self[col] = self[col].astype(str)
 
     def validate(self) -> Self:
         """Validate the dataframe based on the model."""

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -2,7 +2,7 @@
 
 from contextlib import nullcontext
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 import pandas as pd
 import pytest
@@ -22,6 +22,7 @@ class TabularWithModel(BaseTabular):
         a: str
         b: Optional[int] = 0
         c: list = []
+        d: Union[list, str] = []
 
     model: BaseTabularModel = _Model
     index_cols = ["b"]
@@ -37,9 +38,15 @@ class TabularWithModelNoList(BaseTabular):
     index_cols = ["b"]
 
 
-def test_empty_has_columns():
+def test_init_empty_has_columns():
     tabular = TabularWithModel()
     assert set(tabular.columns) == set(TabularWithModel.model.model_fields.keys())
+
+
+def test_init_dtypes():
+    tabular1 = TabularWithModel()
+    tabular2 = TabularWithModel([{"a": "A", "b": 1, "c": [], "d": None}])
+    assert tabular1.dtypes.equals(tabular2.dtypes)
 
 
 def test_sort_index_does_not_change_columns():

--- a/tests/unit/workflows/pipeline_store/test_search.py
+++ b/tests/unit/workflows/pipeline_store/test_search.py
@@ -53,7 +53,7 @@ def test_hits_to_df(workflow: PipelineSearchWorkflow, hits: list[dict]):
     # order is switched because of sorting by downloads
     assert df.iloc[0]["Zenodo ID"] == "[link=fake_doi_url_67890]67890[/link]"
     assert df.iloc[0]["Title"] == "Pipeline 2"
-    assert df.iloc[0]["Description"] is None
+    assert pd.isna(df.iloc[0]["Description"])
     assert df.iloc[0]["Downloads"] == 100
 
     assert df.iloc[1]["Zenodo ID"] == "[link=fake_doi_url_12345]12345[/link]"


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #874 
- Closes #849 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

```
FAILED tests/unit/tabular/test_processing_status.py::test_add_or_update_records[data_orig0-data_new0-data_expected0] - assert False
```
Test failed due to `pandas` now having a `StringDType`, which caused the `BaseTabular.equals()` to return `False` when comparing a column with `object` `dtype` with the new `str` `dtype`. Fixed by having more robust handling of types when instantiating empty `BaseTabular` dataframes. 

```
FAILED tests/unit/workflows/pipeline_store/test_search.py::test_hits_to_df - assert nan is None
```
Changed to a more robust assertion.

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--875.org.readthedocs.build/en/875/

<!-- readthedocs-preview nipoppy end -->