### PR TITLE
[TST] Fix uncollected test and add boundary condition cases

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,100 @@
+# Plan: Improve nipoppy test suite with parametrization and boundary conditions
+
+## Context
+
+The nipoppy test suite has 532 tests across 55 files and already uses `@pytest.mark.parametrize` extensively (~268 instances). However, review found several concrete opportunities: tests that repeat identical patterns without parametrization, a test that never runs due to a naming bug, and missing boundary condition coverage for edge cases the code actually handles.
+
+## Changes
+
+### 1. Fix bug: rename `get_participants_sessions` -> `test_get_participants_sessions`
+
+**File:** `tests/unit/tabular/test_manifest.py:140`
+
+The function is missing the `test_` prefix so pytest never collects it. Simply rename it.
+
+### 2. Add boundary cases to `test_check_participant_id` and `test_check_session_id`
+
+**File:** `tests/unit/utils/test_bids.py`
+
+Add parametrize cases for:
+- Empty string `""` (after prefix removal, `"sub-"` becomes `""` -> `"".isalnum()` is False -> should raise)
+- Already-stripped empty string `""` directly
+
+These are real edge cases the code handles at `bids.py:70`.
+
+### 3. Add boundary cases to `test_apply_substitutions_to_json`
+
+**File:** `tests/unit/utils/test_utils.py`
+
+Add parametrize cases for:
+- Empty substitutions dict `{}` -> returns input unchanged
+- Multiple occurrences of the same key in values
+- Substitution value containing JSON-special chars (backslash) -- verifying it round-trips correctly
+
+### 4. Add boundary cases to `test_process_template_str`
+
+**File:** `tests/unit/utils/test_utils.py`
+
+Add parametrize cases for:
+- Empty string -> returns empty string
+- String with no template patterns -> returns unchanged (already tested with `"no_replace"`, but add `""`)
+- Multiple occurrences of same placeholder in one string
+
+### 5. Add boundary cases to `test_add_path_suffix`
+
+**File:** `tests/unit/utils/test_utils.py`
+
+Add parametrize case for:
+- Path with multiple extensions (e.g., `"file.tar.gz"`)
+
+### 6. Add boundary case to `test_get_diff`: empty self
+
+**File:** `tests/unit/tabular/test_base.py`
+
+Add parametrize case for:
+- Empty self, non-empty other -> returns empty (0 rows in self means 0 in diff)
+
+### 7. Add boundary case to `test_add_or_update_records`: empty records list
+
+**File:** `tests/unit/tabular/test_base.py`
+
+Add parametrize case for:
+- `to_add=[]` -> tabular unchanged
+
+### 8. Add empty-list boundary to `test_get_imaging_subset`
+
+**File:** `tests/unit/tabular/test_manifest.py`
+
+Add parametrize case for:
+- All rows have empty datatype lists `[]` -> returns 0 rows regardless of session_id
+
+### 9. Parametrize `test_model_status_invalid`
+
+**File:** `tests/unit/tabular/test_processing_status.py`
+
+The `test_model_bids_id` and `test_model_status` are already well-structured parametrized tests. The real improvement is parametrizing `test_model_status_invalid` with multiple invalid values:
+
+- `"BAD_STATUS"`, `""`, `"SUCCESS"` (wrong case)
+
+### 10. Add `test_add_bind_arg` boundary case: mode=None
+
+**File:** `tests/unit/test_container.py`
+
+Add parametrize case for `mode=None` -> bind arg should not include mode suffix.
+
+## Files to modify
+
+1. `tests/unit/tabular/test_manifest.py` - fix naming bug, add boundary cases
+2. `tests/unit/utils/test_bids.py` - add empty string boundary cases
+3. `tests/unit/utils/test_utils.py` - add boundary cases to substitution/template/path tests
+4. `tests/unit/tabular/test_base.py` - add empty-data boundary cases
+5. `tests/unit/tabular/test_processing_status.py` - parametrize invalid status test
+6. `tests/unit/test_container.py` - add mode=None boundary case
+
+## Verification
+
+```bash
+pytest tests/unit/tabular/test_manifest.py tests/unit/utils/test_bids.py tests/unit/utils/test_utils.py tests/unit/tabular/test_base.py tests/unit/tabular/test_processing_status.py tests/unit/test_container.py -v
+```
+
+Confirm all new tests pass, and the previously-hidden `test_get_participants_sessions` now runs.

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -155,6 +155,7 @@ def test_validate_duplicate_records(data):
             1,
         ),
         ({"a": ["A", "B", "C", "D"], "b": [1, 2, 3, 4]}, {"a": [], "b": []}, 4),
+        ({"a": [], "b": []}, {"a": ["A", "B"], "b": [1, 2]}, 0),
     ],
 )
 def test_get_diff(data1, data2, expected_count):
@@ -190,6 +191,12 @@ def test_get_diff_invalid_cols():
 @pytest.mark.parametrize(
     "original,index_cols,to_add,expected",
     [
+        [
+            [{"a": "A", "b": 1}],
+            ["b"],
+            [],
+            [{"a": "A", "b": 1}],
+        ],
         [
             [{"a": "A", "b": 1}],
             ["b"],

--- a/tests/unit/tabular/test_manifest.py
+++ b/tests/unit/tabular/test_manifest.py
@@ -137,31 +137,29 @@ def test_get_imaging_subset(data, session_id, expected_count):
         ("03", "ses-BL", 1),
     ],
 )
-def get_participants_sessions(participant_id, session_id, expected_count):
-    data = (
-        {
-            "participant_id": ["01", "01", "01", "02", "02", "03", "04"],
-            "visit": ["BL", "M12", "M24", "BL", "M12", "BL", "SC"],
-            "session_id": [
-                "ses-BL",
-                "ses-M12",
-                "ses-M24",
-                "ses-BL",
-                "ses-M12",
-                "ses-BL",
-                None,
-            ],
-            "datatype": [
-                ["anat"],
-                ["anat"],
-                ["anat"],
-                ["anat"],
-                ["anat"],
-                ["anat"],
-                [],
-            ],
-        },
-    )
+def test_get_participants_sessions(participant_id, session_id, expected_count):
+    data = {
+        "participant_id": ["01", "01", "01", "02", "02", "03", "04"],
+        "visit_id": ["BL", "M12", "M24", "BL", "M12", "BL", "SC"],
+        "session_id": [
+            "ses-BL",
+            "ses-M12",
+            "ses-M24",
+            "ses-BL",
+            "ses-M12",
+            "ses-BL",
+            None,
+        ],
+        "datatype": [
+            ["anat"],
+            ["anat"],
+            ["anat"],
+            ["anat"],
+            ["anat"],
+            ["anat"],
+            [],
+        ],
+    }
     manifest = Manifest(data)
     count = 0
     for _ in manifest.get_participants_sessions(

--- a/tests/unit/tabular/test_manifest.py
+++ b/tests/unit/tabular/test_manifest.py
@@ -77,6 +77,11 @@ def test_validate_sessions_visits(session_ids, visit_ids, is_valid):
     "data,session_id,expected_count",
     [
         (
+            (["01", "02"], ["BL", "M12"], [None, None], [["anat"], ["anat"]]),
+            None,
+            0,
+        ),
+        (
             (["01"], ["BL"], None, [[]]),
             "BL",
             0,

--- a/tests/unit/tabular/test_processing_status.py
+++ b/tests/unit/tabular/test_processing_status.py
@@ -84,7 +84,8 @@ def test_model_status(status):
     assert model.status == status
 
 
-def test_model_status_invalid():
+@pytest.mark.parametrize("status", ["BAD_STATUS", "", "success"])
+def test_model_status_invalid(status):
     with pytest.raises(TabularError):
         ProcessingStatusModel(
             participant_id="1",
@@ -92,7 +93,7 @@ def test_model_status_invalid():
             pipeline_name="my_pipeline",
             pipeline_version="1.0",
             pipeline_step="step1",
-            status="BAD_STATUS",
+            status=status,
         )
 
 

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -106,6 +106,13 @@ def test_check_command_exists_error(
                 f"{Path('relative_path').resolve()}:{Path('relative_path').resolve()}:rw",  # noqa: E501
             ],
         ),
+        (
+            [],
+            "/my/local/path",
+            None,
+            None,
+            ["-B", "/my/local/path:/my/local/path"],
+        ),
     ],
 )
 def test_add_bind_arg(

--- a/tests/unit/utils/test_bids.py
+++ b/tests/unit/utils/test_bids.py
@@ -44,6 +44,8 @@ def test_session_id_to_bids_session_id(session, expected):
         (None, True, True, None),
         ("P-01", True, False, None),
         ("sub_01", False, False, None),
+        ("", False, False, None),
+        ("sub-", False, False, None),
     ],
 )
 def test_check_participant_id(participant_id, raise_error, is_valid, expected):
@@ -68,6 +70,8 @@ def test_check_participant_id(participant_id, raise_error, is_valid, expected):
         (None, True, True, None),
         ("-01", True, False, None),
         ("1_", False, False, None),
+        ("", False, False, None),
+        ("ses-", False, False, None),
     ],
 )
 def test_check_session_id(session_id, raise_error, is_valid, expected):

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -86,6 +86,12 @@ def test_save_json(tmp_path: Path):
             "-",
             Path("file_without_extension-suffix"),
         ),
+        (
+            "archive.tar.gz",
+            "backup",
+            "-",
+            Path("archive.tar-backup.gz"),
+        ),
     ],
 )
 def test_add_path_suffix(path, suffix, sep, expected):
@@ -143,6 +149,7 @@ def test_save_df_with_backup_broken_symlink(tmp_path: Path):
 @pytest.mark.parametrize(
     "template_str,resolve_paths,objs,kwargs,expected",
     [
+        ("", False, None, {}, ""),
         ("no_replace", False, None, {}, "no_replace"),
         (
             "[[NIPOPPY_DPATH_ROOT]]",
@@ -164,6 +171,13 @@ def test_save_df_with_backup_broken_symlink(tmp_path: Path):
             [],
             {"some_kwarg_path": Path("a_path")},
             str(Path("a_path").resolve()),
+        ),
+        (
+            "[[NIPOPPY_DPATH_ROOT]]/sub/[[NIPOPPY_DPATH_ROOT]]",
+            False,
+            [DatasetLayout("my_dataset")],
+            {},
+            "my_dataset/sub/my_dataset",
         ),
     ],
 )
@@ -198,6 +212,12 @@ def test_process_template_str_error_replace():
         ({"key1": "TO_REPLACE"}, {"TO_REPLACE": "value1"}, {"key1": "value1"}),
         ({"key1": ["TO_REPLACE"]}, {"TO_REPLACE": "value1"}, {"key1": ["value1"]}),
         ([{"key1": "TO_REPLACE"}], {"TO_REPLACE": "value1"}, [{"key1": "value1"}]),
+        ({"key1": "value1"}, {}, {"key1": "value1"}),
+        (
+            {"key1": "A_B_A"},
+            {"A": "X"},
+            {"key1": "X_B_X"},
+        ),
     ],
 )
 def test_apply_substitutions_to_json(json_obj, substitutions, expected_output):


### PR DESCRIPTION
## Summary

- Fix `test_get_participants_sessions` which was never collected by pytest due to missing `test_` prefix (also fixed two data bugs in the test: trailing-comma tuple, wrong column name `"visit"` -> `"visit_id"`)
- Add boundary condition cases to existing parametrized tests across 6 files: empty strings for BIDS ID validation, empty DataFrames, empty substitution dicts, repeated placeholders, multi-extension paths, `mode=None` for container bind args, case-sensitive status rejection

## Test plan

- [x] All 265 tests pass across the 6 modified files (`pytest -n 0`)
- [x] The 10 previously-hidden `test_get_participants_sessions` cases now run and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--896.org.readthedocs.build/en/896/

<!-- readthedocs-preview nipoppy end -->