### PR TITLE
[ENH] Set Zenodo record default preview to always be `config.json`

### DIFF
--- a/nipoppy/workflows/pipeline_store/upload.py
+++ b/nipoppy/workflows/pipeline_store/upload.py
@@ -7,6 +7,7 @@ from nipoppy.config.pipeline import BasePipelineConfig
 from nipoppy.console import CONSOLE_STDOUT
 from nipoppy.env import StrOrPathLike
 from nipoppy.exceptions import TerminatedByUserError, WorkflowError
+from nipoppy.layout import DatasetLayout
 from nipoppy.logger import get_logger
 from nipoppy.pipeline_validation import check_pipeline_bundle
 from nipoppy.utils.utils import get_today, load_json
@@ -144,7 +145,10 @@ class PipelineUploadWorkflow(BaseWorkflow):
         zenodo_metadata = pipeline_dir.joinpath("zenodo.json")
         metadata = self._get_pipeline_metadata(zenodo_metadata, pipeline_config)
         doi = self.zenodo_api.upload_record(
-            input_dir=pipeline_dir, record_id=self.record_id, metadata=metadata
+            input_dir=pipeline_dir,
+            record_id=self.record_id,
+            metadata=metadata,
+            default_preview_filename=DatasetLayout.fname_pipeline_config,
         )
         logger.success(f"Pipeline successfully uploaded at {doi}")
 

--- a/nipoppy/workflows/pipeline_store/upload.py
+++ b/nipoppy/workflows/pipeline_store/upload.py
@@ -143,7 +143,7 @@ class PipelineUploadWorkflow(BaseWorkflow):
 
         zenodo_metadata = pipeline_dir.joinpath("zenodo.json")
         metadata = self._get_pipeline_metadata(zenodo_metadata, pipeline_config)
-        doi = self.zenodo_api.upload_pipeline(
+        doi = self.zenodo_api.upload_record(
             input_dir=pipeline_dir, record_id=self.record_id, metadata=metadata
         )
         logger.success(f"Pipeline successfully uploaded at {doi}")

--- a/nipoppy/zenodo_api.py
+++ b/nipoppy/zenodo_api.py
@@ -117,7 +117,18 @@ class ZenodoAPI:
 
             output_dir.joinpath(file).write_bytes(response.content)
 
-    def _create_new_version(self, record_id: str, metadata: dict) -> Tuple[str, str]:
+    def _update_metadata(self, record_id: str, metadata: dict):
+        response = httpx.put(
+            f"{self.api_endpoint}/records/{record_id}/draft",
+            headers=self.headers,
+            json=metadata,
+        )
+        if response.status_code != 200:
+            raise ZenodoAPIError(
+                f"Failed to update metadata for zenodo.{record_id}: {response.json()}"
+            )
+
+    def _create_new_version(self, record_id: str) -> Tuple[str, str]:
         response = httpx.post(
             f"{self.api_endpoint}/records/{record_id}/versions",
             headers=self.headers,
@@ -129,32 +140,19 @@ class ZenodoAPI:
             )
         new_record_id = response.json()["id"]
         owner_id = response.json()["owners"][0]["id"]
-
-        # Required to update the metadata to include the new publication date
-        response = httpx.put(
-            f"{self.api_endpoint}/records/{new_record_id}/draft",
-            headers=self.headers,
-            json=metadata,
-        )
-        if response.status_code != 200:
-            raise ZenodoAPIError(
-                f"Failed to update metadata for zenodo.{record_id}: {response.json()}"
-            )
-
         return new_record_id, owner_id
 
-    def _create_draft(self, metadata: dict) -> Tuple[str, str]:
+    def _create_draft(self) -> Tuple[str, str]:
         response = httpx.post(
             f"{self.api_endpoint}/records",
             headers=self.headers | {"Content-Type": "application/json"},
-            json=metadata,
         )
         if response.status_code != 201:
             raise ZenodoAPIError(f"Failed to create a draft record: {response.json()}")
 
         return response.json()["id"], response.json()["owners"][0]["id"]
 
-    def _update_creators(self, record_id: str, owner_id: str, metadata: dict):
+    def _add_creators_to_metadata(self, owner_id: str, metadata: dict) -> dict:
         # get user profile info
         response = httpx.get(
             f"{self.api_endpoint}/users/{owner_id}", headers=self.headers
@@ -190,15 +188,7 @@ class ZenodoAPI:
                 "affiliations": [{"name": affiliation}] if affiliation else [],
             }
         ]
-        response = httpx.put(
-            f"{self.api_endpoint}/records/{record_id}/draft",
-            headers=self.headers,
-            json=metadata,
-        )
-        if response.status_code != 200:
-            raise ZenodoAPIError(
-                f"Failed to update metadata for zenodo.{record_id}: {response.json()}"
-            )
+        return metadata
 
     def _upload_files(self, files: list[Path], record_id: str):
         metadata = [{"key": file.name} for file in files]
@@ -238,6 +228,14 @@ class ZenodoAPI:
                     f"\n{response.json()}"
                 )
 
+    def _add_default_preview_to_metadata(self, metadata: dict, file_name: str) -> dict:
+        """Set the default preview file.
+
+        Note: the metadata update must be done after the files are uploaded.
+        """
+        metadata["files"] = {"default_preview": file_name}
+        return metadata
+
     def _publish(self, record_id: str) -> str:
         response = httpx.post(
             f"{self.api_endpoint}/records/{record_id}/draft/actions/publish",
@@ -263,6 +261,7 @@ class ZenodoAPI:
         input_dir: Path,
         metadata: dict,
         record_id: Optional[str] = None,
+        default_preview_filename: Optional[str] = None,
     ) -> str:
         """Upload a pipeline to Zenodo."""
         record_id = self._process_record_id(record_id)
@@ -274,18 +273,27 @@ class ZenodoAPI:
         self._check_authentication()
 
         if record_id:
-            record_id, owner_id = self._create_new_version(record_id, metadata)
+            record_id, owner_id = self._create_new_version(
+                self.get_latest_version_id(record_id)
+            )
             action = "update"
         else:
-            record_id, owner_id = self._create_draft(metadata)
+            record_id, owner_id = self._create_draft()
             action = "creation"
 
         try:
             if not metadata["metadata"].get("creators"):
-                self._update_creators(record_id, owner_id, metadata)
+                metadata = self._add_creators_to_metadata(owner_id, metadata)
 
             files = sorted(input_dir.iterdir())
             self._upload_files(files, record_id)
+
+            if default_preview_filename is not None:
+                metadata = self._add_default_preview_to_metadata(
+                    metadata, default_preview_filename
+                )
+
+            self._update_metadata(record_id, metadata)
             doi = self._publish(record_id)
             return doi
 

--- a/nipoppy/zenodo_api.py
+++ b/nipoppy/zenodo_api.py
@@ -233,7 +233,9 @@ class ZenodoAPI:
 
         Note: the metadata update must be done after the files are uploaded.
         """
-        metadata["files"] = {"default_preview": file_name}
+        if "files" not in metadata:
+            metadata["files"] = {}
+        metadata["files"]["default_preview"] = file_name
         return metadata
 
     def _publish(self, record_id: str) -> str:

--- a/nipoppy/zenodo_api.py
+++ b/nipoppy/zenodo_api.py
@@ -256,7 +256,7 @@ class ZenodoAPI:
         if response.status_code != 200:
             raise ZenodoAPIError(f"Failed to authenticate to Zenodo: {response.json()}")
 
-    def upload_pipeline(
+    def upload_record(
         self,
         input_dir: Path,
         metadata: dict,

--- a/tests/data/fmriprep-24.1.1/abc.txt
+++ b/tests/data/fmriprep-24.1.1/abc.txt
@@ -1,0 +1,1 @@
+This file should not be the default preview.

--- a/tests/integration/test_zenodo_api.py
+++ b/tests/integration/test_zenodo_api.py
@@ -103,7 +103,7 @@ def test_create_new_version_invalid_record(zenodo_api: ZenodoAPI, metadata: dict
     with pytest.raises(
         ZenodoAPIError,
         match=(
-            f"Failed to create a new version for zenodo.{record_id}: "
+            f"Failed to get latest version for zenodo.{record_id}: "
             "{'status': 404, 'message': 'The persistent identifier does not exist.'}"
         ),
     ):

--- a/tests/integration/test_zenodo_api.py
+++ b/tests/integration/test_zenodo_api.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 
+import httpx
 import pytest
 
 from nipoppy.zenodo_api import ZenodoAPI, ZenodoAPIError
@@ -120,11 +121,21 @@ def test_create_new_version_invalid_record(zenodo_api: ZenodoAPI, metadata: dict
     reason="Requires Zenodo token",
 )
 def test_create_new_record(zenodo_api: ZenodoAPI, metadata: dict):
+    default_preview = "config.json"
+
     zenodo_api.set_authorization(os.environ["ZENODO_TOKEN"])
-    zenodo_api.upload_record(
+    doi = zenodo_api.upload_record(
         input_dir=TEST_PIPELINE,
         metadata=metadata,
+        default_preview_filename=default_preview,
     )
+
+    # extract the new record ID from the DOI (e.g. 10.5072/zenodo.123456)
+    new_record_id = doi.split("/")[-1].removeprefix("zenodo.")
+
+    # verify that the default preview file is set correctly
+    response = httpx.get(f"{zenodo_api.api_endpoint}/records/{new_record_id}/files")
+    assert response.json()["default_preview"] == default_preview
 
 
 @pytest.mark.api

--- a/tests/integration/test_zenodo_api.py
+++ b/tests/integration/test_zenodo_api.py
@@ -84,7 +84,7 @@ def test_download_invalid_record(tmp_path: Path, zenodo_api: ZenodoAPI):
 )
 def test_create_new_version(zenodo_api: ZenodoAPI, metadata: dict):
     zenodo_api.set_authorization(os.environ["ZENODO_TOKEN"])
-    zenodo_api.upload_pipeline(
+    zenodo_api.upload_record(
         input_dir=TEST_PIPELINE,
         metadata=metadata,
         record_id=os.environ["ZENODO_ID"],
@@ -107,7 +107,7 @@ def test_create_new_version_invalid_record(zenodo_api: ZenodoAPI, metadata: dict
             "{'status': 404, 'message': 'The persistent identifier does not exist.'}"
         ),
     ):
-        zenodo_api.upload_pipeline(
+        zenodo_api.upload_record(
             input_dir=TEST_PIPELINE,
             metadata=metadata,
             record_id=record_id,
@@ -121,7 +121,7 @@ def test_create_new_version_invalid_record(zenodo_api: ZenodoAPI, metadata: dict
 )
 def test_create_new_record(zenodo_api: ZenodoAPI, metadata: dict):
     zenodo_api.set_authorization(os.environ["ZENODO_TOKEN"])
-    zenodo_api.upload_pipeline(
+    zenodo_api.upload_record(
         input_dir=TEST_PIPELINE,
         metadata=metadata,
     )
@@ -138,7 +138,7 @@ def test_create_new_record_invalid_token(zenodo_api: ZenodoAPI, metadata: dict):
             "{'status': 403, 'message': 'Permission denied.'}"
         ),
     ):
-        zenodo_api.upload_pipeline(
+        zenodo_api.upload_record(
             input_dir=TEST_PIPELINE,
             metadata=metadata,
         )

--- a/tests/unit/test_zenodo_api.py
+++ b/tests/unit/test_zenodo_api.py
@@ -547,7 +547,7 @@ def test_check_authentication_fails(
         (None, "_create_draft"),
     ],
 )
-def test_upload_pipeline(
+def test_upload_record(
     record_id: str | None,
     create_method_name: str,
     tmp_path: Path,
@@ -578,7 +578,7 @@ def test_upload_pipeline(
     mocked_publish = mocker.patch.object(zenodo_api, "_publish", return_value=doi)
 
     assert (
-        zenodo_api.upload_pipeline(
+        zenodo_api.upload_record(
             input_dir=tmp_path, metadata=metadata, record_id=record_id
         )
         == doi
@@ -594,7 +594,7 @@ def test_upload_pipeline(
     mocked_publish.assert_called_once_with(new_record_id)
 
 
-def test_upload_pipeline_custom_creators(
+def test_upload_record_custom_creators(
     tmp_path: Path, zenodo_api: ZenodoAPI, mocker: pytest_mock.MockerFixture
 ):
     mocker.patch.object(zenodo_api, "_check_authentication")
@@ -606,7 +606,7 @@ def test_upload_pipeline_custom_creators(
     mocker.patch.object(zenodo_api, "_update_metadata")
     mocker.patch.object(zenodo_api, "_publish", return_value="fake_doi")
 
-    zenodo_api.upload_pipeline(
+    zenodo_api.upload_record(
         input_dir=tmp_path,
         metadata={
             "metadata": {
@@ -625,16 +625,16 @@ def test_upload_pipeline_custom_creators(
     mocked_add_creators_to_metadata.assert_not_called()
 
 
-def test_upload_pipeline_dir_not_found(zenodo_api: ZenodoAPI):
+def test_upload_record_dir_not_found(zenodo_api: ZenodoAPI):
     with pytest.raises(FileNotFoundError):
-        zenodo_api.upload_pipeline(input_dir=Path("fake_path"), metadata={})
+        zenodo_api.upload_record(input_dir=Path("fake_path"), metadata={})
 
 
-def test_upload_pipeline_not_a_dir(tmp_path: Path, zenodo_api: ZenodoAPI):
+def test_upload_record_not_a_dir(tmp_path: Path, zenodo_api: ZenodoAPI):
     input_path = tmp_path / "file.txt"
     input_path.write_text("this is a file, not a directory")
     with pytest.raises(NotADirectoryError, match=f"{input_path} must be a directory"):
-        zenodo_api.upload_pipeline(input_dir=input_path, metadata={})
+        zenodo_api.upload_record(input_dir=input_path, metadata={})
 
 
 @pytest.mark.parametrize(
@@ -642,7 +642,7 @@ def test_upload_pipeline_not_a_dir(tmp_path: Path, zenodo_api: ZenodoAPI):
     [(204, "Record creation reverted"), (500, "Failed to revert record")],
 )
 @pytest.mark.no_xdist
-def test_upload_pipeline_delete_draft(
+def test_upload_record_delete_draft(
     delete_request_status_code: int,
     expected_log_message: str,
     tmp_path: Path,
@@ -669,7 +669,7 @@ def test_upload_pipeline_delete_draft(
     )
 
     with pytest.raises(ZenodoAPIError):
-        zenodo_api.upload_pipeline(
+        zenodo_api.upload_record(
             input_dir=tmp_path,
             metadata={"metadata": {}},
         )

--- a/tests/unit/test_zenodo_api.py
+++ b/tests/unit/test_zenodo_api.py
@@ -477,6 +477,12 @@ def test_upload_files_commit_fails(
         zenodo_api._upload_files(files=[tmp_path / filename], record_id=record_id)
 
 
+@pytest.mark.parametrize("filename", ["abc.txt", "def.txt"])
+def test_add_default_preview_to_metadata(zenodo_api: ZenodoAPI, filename: str):
+    updated_metadata = zenodo_api._add_default_preview_to_metadata({}, filename)
+    assert updated_metadata["files"]["default_preview"] == filename
+
+
 def test_publish(zenodo_api: ZenodoAPI, httpx_mock: pytest_httpx.HTTPXMock):
     record_id = "123456"
     doi = "fake_doi"

--- a/tests/unit/test_zenodo_api.py
+++ b/tests/unit/test_zenodo_api.py
@@ -137,14 +137,60 @@ def test_download_record_files_checksum_mismatch(
         zenodo_api.download_record_files(output_dir=tmp_path, record_id=record_id)
 
 
-def test_create_new_version(zenodo_api: ZenodoAPI, httpx_mock: pytest_httpx.HTTPXMock):
+def test_update_metadata(zenodo_api: ZenodoAPI, httpx_mock: pytest_httpx.HTTPXMock):
+    record_id = "123456"
+    headers = {
+        "Authorization": "Bearer mocked_api",
+    }
+    metadata = {"metadata": {}}
+
+    httpx_mock.add_response(
+        url=f"{zenodo_api.api_endpoint}/records/{record_id}/draft",
+        method="PUT",
+        status_code=200,
+        json={},
+        match_headers=headers,
+        match_json=metadata,
+    )
+
+    zenodo_api._update_metadata(record_id=record_id, metadata=metadata)
+
+
+def test_update_metadata_fails(
+    zenodo_api: ZenodoAPI, httpx_mock: pytest_httpx.HTTPXMock
+):
+    record_id = "123456"
+    headers = {
+        "Authorization": "Bearer mocked_api",
+    }
+    metadata = {"metadata": {}}
+
+    httpx_mock.add_response(
+        url=f"{zenodo_api.api_endpoint}/records/{record_id}/draft",
+        method="PUT",
+        status_code=500,
+        json={},
+        match_headers=headers,
+        match_json=metadata,
+    )
+
+    with pytest.raises(
+        ZenodoAPIError,
+        match=f"Failed to update metadata for zenodo.{record_id}",
+    ):
+        zenodo_api._update_metadata(record_id=record_id, metadata=metadata)
+
+
+def test_create_new_version(
+    zenodo_api: ZenodoAPI,
+    httpx_mock: pytest_httpx.HTTPXMock,
+):
     record_id = "123456"
     new_record_id = "654321"
     owner_id = "888888"
     headers = {
         "Authorization": "Bearer mocked_api",
     }
-    metadata = {"metadata": {}}
 
     httpx_mock.add_response(
         url=f"{zenodo_api.api_endpoint}/records/{record_id}/versions",
@@ -153,27 +199,21 @@ def test_create_new_version(zenodo_api: ZenodoAPI, httpx_mock: pytest_httpx.HTTP
         json={"id": new_record_id, "owners": [{"id": owner_id}]},
         match_headers=headers,
     )
-    httpx_mock.add_response(
-        url=f"{zenodo_api.api_endpoint}/records/{new_record_id}/draft",
-        method="PUT",
-        match_headers=headers,
-        match_json=metadata,
-    )
 
-    assert zenodo_api._create_new_version(record_id=record_id, metadata=metadata) == (
+    assert zenodo_api._create_new_version(record_id=record_id) == (
         new_record_id,
         owner_id,
     )
 
 
 def test_create_new_version_fails(
-    zenodo_api: ZenodoAPI, httpx_mock: pytest_httpx.HTTPXMock
+    zenodo_api: ZenodoAPI,
+    httpx_mock: pytest_httpx.HTTPXMock,
 ):
     record_id = "123456"
     headers = {
         "Authorization": "Bearer mocked_api",
     }
-    metadata = {"metadata": {}}
 
     httpx_mock.add_response(
         url=f"{zenodo_api.api_endpoint}/records/{record_id}/versions",
@@ -186,46 +226,11 @@ def test_create_new_version_fails(
     with pytest.raises(
         ZenodoAPIError, match=f"Failed to create a new version for zenodo.{record_id}"
     ):
-        zenodo_api._create_new_version(record_id=record_id, metadata=metadata)
-
-
-def test_create_new_version_metadata_update_fails(
-    zenodo_api: ZenodoAPI, httpx_mock: pytest_httpx.HTTPXMock
-):
-    record_id = "123456"
-    new_record_id = "654321"
-    owner_id = "888888"
-    headers = {
-        "Authorization": "Bearer mocked_api",
-    }
-    metadata = {"metadata": {}}
-
-    httpx_mock.add_response(
-        url=f"{zenodo_api.api_endpoint}/records/{record_id}/versions",
-        method="POST",
-        status_code=201,
-        json={"id": new_record_id, "owners": [{"id": owner_id}]},
-        match_headers=headers,
-    )
-    httpx_mock.add_response(
-        url=f"{zenodo_api.api_endpoint}/records/{new_record_id}/draft",
-        method="PUT",
-        status_code=500,
-        json={},
-        match_headers=headers,
-        match_json=metadata,
-    )
-
-    with pytest.raises(
-        ZenodoAPIError,
-        match=f"Failed to update metadata for zenodo.{record_id}",
-    ):
-        zenodo_api._create_new_version(record_id=record_id, metadata=metadata)
+        zenodo_api._create_new_version(record_id=record_id)
 
 
 def test_create_draft(zenodo_api: ZenodoAPI, httpx_mock: pytest_httpx.HTTPXMock):
     # Set mock response
-    metadata = {"metadata": dict()}
     httpx_mock.add_response(
         url=f"{zenodo_api.api_endpoint}/records",
         status_code=201,
@@ -235,17 +240,15 @@ def test_create_draft(zenodo_api: ZenodoAPI, httpx_mock: pytest_httpx.HTTPXMock)
             "Authorization": "Bearer mocked_api",
             "Content-Type": "application/json",
         },
-        match_json=metadata,
     )
 
     # Assertions
-    result = zenodo_api._create_draft(metadata)
+    result = zenodo_api._create_draft()
     assert result == ("123456", "987")
 
 
 def test_create_draft_fails(zenodo_api: ZenodoAPI, httpx_mock: pytest_httpx.HTTPXMock):
     # Set mock response
-    metadata = {"metadata": dict()}
     httpx_mock.add_response(
         url=f"{zenodo_api.api_endpoint}/records",
         method="POST",
@@ -259,7 +262,7 @@ def test_create_draft_fails(zenodo_api: ZenodoAPI, httpx_mock: pytest_httpx.HTTP
 
     # Assertions
     with pytest.raises(ZenodoAPIError, match="Failed to create a draft record:"):
-        zenodo_api._create_draft(metadata)
+        zenodo_api._create_draft()
 
 
 @pytest.mark.parametrize(
@@ -302,13 +305,12 @@ def test_create_draft_fails(zenodo_api: ZenodoAPI, httpx_mock: pytest_httpx.HTTP
         ),
     ],
 )
-def test_update_creators(
+def test_add_creators_to_metadata(
     json_response,
     expected_creators,
     zenodo_api: ZenodoAPI,
     httpx_mock: pytest_httpx.HTTPXMock,
 ):
-    record_id = "123456"
     owner_id = "888888"
     metadata = {"metadata": {}}
 
@@ -318,20 +320,15 @@ def test_update_creators(
         url=f"{zenodo_api.api_endpoint}/users/{owner_id}",
         json=json_response,
     )
-    httpx_mock.add_response(
-        url=f"{zenodo_api.api_endpoint}/records/{record_id}/draft",
-        method="PUT",
-        match_json={"metadata": {"creators": expected_creators}},
-    )
 
-    zenodo_api._update_creators(record_id, owner_id, metadata)
+    updated_metadata = zenodo_api._add_creators_to_metadata(owner_id, metadata)
+    assert updated_metadata["metadata"]["creators"] == expected_creators
 
 
-def test_update_creators_invalid_id(
+def test_add_creators_to_metadata_invalid_id(
     zenodo_api: ZenodoAPI,
     httpx_mock: pytest_httpx.HTTPXMock,
 ):
-    record_id = "123456"
     owner_id = "888888"
     metadata = {"metadata": {}}
 
@@ -347,35 +344,7 @@ def test_update_creators_invalid_id(
         ZenodoAPIError,
         match=f"Failed to get information for user {owner_id}",
     ):
-        zenodo_api._update_creators(record_id, owner_id, metadata)
-
-
-def test_update_creators_metadata_update_fails(
-    zenodo_api: ZenodoAPI,
-    httpx_mock: pytest_httpx.HTTPXMock,
-):
-    record_id = "123456"
-    owner_id = "888888"
-    metadata = {"metadata": {}}
-
-    # mock the API
-    httpx_mock.add_response(
-        method="GET",
-        url=f"{zenodo_api.api_endpoint}/users/{owner_id}",
-        json={"profile": {}, "identities": {}, "username": "fake_user"},
-    )
-    httpx_mock.add_response(
-        url=f"{zenodo_api.api_endpoint}/records/{record_id}/draft",
-        method="PUT",
-        status_code=500,
-        json={},
-    )
-
-    with pytest.raises(
-        ZenodoAPIError,
-        match=f"Failed to update metadata for zenodo.{record_id}",
-    ):
-        zenodo_api._update_creators(record_id, owner_id, metadata)
+        zenodo_api._add_creators_to_metadata(owner_id, metadata)
 
 
 @pytest.mark.parametrize(
@@ -591,11 +560,15 @@ def test_upload_pipeline(
     mocked_check_authentication = mocker.patch.object(
         zenodo_api, "_check_authentication"
     )
+    mocker.patch.object(zenodo_api, "get_latest_version_id", return_value=record_id)
     mocked_create = mocker.patch.object(
         zenodo_api, create_method_name, return_value=(new_record_id, owner_id)
     )
-    mocked_update_creators = mocker.patch.object(zenodo_api, "_update_creators")
+    mocked_add_creators_to_metadata = mocker.patch.object(
+        zenodo_api, "_add_creators_to_metadata", return_value=metadata
+    )
     mocked_upload_files = mocker.patch.object(zenodo_api, "_upload_files")
+    mocked_update_metadata = mocker.patch.object(zenodo_api, "_update_metadata")
     mocked_publish = mocker.patch.object(zenodo_api, "_publish", return_value=doi)
 
     assert (
@@ -607,14 +580,12 @@ def test_upload_pipeline(
 
     mocked_check_authentication.assert_called_once()
     mocked_create.assert_called_once()
-    mocked_update_creators.assert_called_once_with(new_record_id, owner_id, metadata)
+    mocked_add_creators_to_metadata.assert_called_once_with(owner_id, metadata)
     mocked_upload_files.assert_called_once_with(
         [tmp_path / fname for fname in fnames], new_record_id
     )
+    mocked_update_metadata.assert_called_once_with(new_record_id, metadata)
     mocked_publish.assert_called_once_with(new_record_id)
-
-    # last positional argument is metadata
-    assert mocked_create.call_args[0][-1] == metadata
 
 
 def test_upload_pipeline_custom_creators(
@@ -622,8 +593,11 @@ def test_upload_pipeline_custom_creators(
 ):
     mocker.patch.object(zenodo_api, "_check_authentication")
     mocker.patch.object(zenodo_api, "_create_draft", return_value=("654321", "888888"))
-    mocked_update_creators = mocker.patch.object(zenodo_api, "_update_creators")
+    mocked_add_creators_to_metadata = mocker.patch.object(
+        zenodo_api, "_add_creators_to_metadata"
+    )
     mocker.patch.object(zenodo_api, "_upload_files")
+    mocker.patch.object(zenodo_api, "_update_metadata")
     mocker.patch.object(zenodo_api, "_publish", return_value="fake_doi")
 
     zenodo_api.upload_pipeline(
@@ -642,7 +616,7 @@ def test_upload_pipeline_custom_creators(
             }
         },
     )
-    mocked_update_creators.assert_not_called()
+    mocked_add_creators_to_metadata.assert_not_called()
 
 
 def test_upload_pipeline_dir_not_found(zenodo_api: ZenodoAPI):
@@ -676,7 +650,7 @@ def test_upload_pipeline_delete_draft(
     # mock functions/API calls
     mocker.patch.object(zenodo_api, "_check_authentication")
     mocker.patch.object(zenodo_api, "_create_draft", return_value=(record_id, "888888"))
-    mocker.patch.object(zenodo_api, "_update_creators")
+    mocker.patch.object(zenodo_api, "_add_creators_to_metadata")
     mocker.patch.object(zenodo_api, "_upload_files")
     mocker.patch.object(
         zenodo_api, "_publish", side_effect=ZenodoAPIError("Publish failed")

--- a/tests/unit/test_zenodo_api.py
+++ b/tests/unit/test_zenodo_api.py
@@ -574,6 +574,9 @@ def test_upload_record(
         zenodo_api, "_add_creators_to_metadata", return_value=metadata
     )
     mocked_upload_files = mocker.patch.object(zenodo_api, "_upload_files")
+    mocked_add_default_preview_to_metadata = mocker.patch.object(
+        zenodo_api, "_add_default_preview_to_metadata", return_value=metadata
+    )
     mocked_update_metadata = mocker.patch.object(zenodo_api, "_update_metadata")
     mocked_publish = mocker.patch.object(zenodo_api, "_publish", return_value=doi)
 
@@ -590,6 +593,7 @@ def test_upload_record(
     mocked_upload_files.assert_called_once_with(
         [tmp_path / fname for fname in fnames], new_record_id
     )
+    mocked_add_default_preview_to_metadata.assert_not_called()
     mocked_update_metadata.assert_called_once_with(new_record_id, metadata)
     mocked_publish.assert_called_once_with(new_record_id)
 
@@ -623,6 +627,32 @@ def test_upload_record_custom_creators(
         },
     )
     mocked_add_creators_to_metadata.assert_not_called()
+
+
+def test_upload_record_default_preview(
+    tmp_path: Path, zenodo_api: ZenodoAPI, mocker: pytest_mock.MockerFixture
+):
+    metadata = {"metadata": {}}
+    fnames = ["abc.txt", "def.txt"]
+    for fname in fnames:
+        (tmp_path / fname).write_text(fname)
+
+    mocker.patch.object(zenodo_api, "_check_authentication")
+    mocker.patch.object(zenodo_api, "_create_draft", return_value=("654321", "888888"))
+    mocker.patch.object(zenodo_api, "_add_creators_to_metadata", return_value=metadata)
+    mocker.patch.object(zenodo_api, "_upload_files")
+    mocked_add_default_preview_to_metadata = mocker.patch.object(
+        zenodo_api, "_add_default_preview_to_metadata", return_value=metadata
+    )
+    mocker.patch.object(zenodo_api, "_update_metadata")
+    mocker.patch.object(zenodo_api, "_publish", return_value="fake_doi")
+
+    zenodo_api.upload_record(
+        input_dir=tmp_path,
+        metadata=metadata,
+        default_preview_filename=fnames[-1],
+    )
+    mocked_add_default_preview_to_metadata.assert_called_once_with(metadata, fnames[-1])
 
 
 def test_upload_record_dir_not_found(zenodo_api: ZenodoAPI):

--- a/tests/unit/test_zenodo_api.py
+++ b/tests/unit/test_zenodo_api.py
@@ -477,10 +477,24 @@ def test_upload_files_commit_fails(
         zenodo_api._upload_files(files=[tmp_path / filename], record_id=record_id)
 
 
-@pytest.mark.parametrize("filename", ["abc.txt", "def.txt"])
-def test_add_default_preview_to_metadata(zenodo_api: ZenodoAPI, filename: str):
-    updated_metadata = zenodo_api._add_default_preview_to_metadata({}, filename)
-    assert updated_metadata["files"]["default_preview"] == filename
+@pytest.mark.parametrize(
+    "input_metadata,filename,expected_output",
+    [
+        (
+            {"files": {"existing_field": "value"}},
+            "abc.txt",
+            {"files": {"existing_field": "value", "default_preview": "abc.txt"}},
+        ),
+        ({}, "def.txt", {"files": {"default_preview": "def.txt"}}),
+    ],
+)
+def test_add_default_preview_to_metadata(
+    zenodo_api: ZenodoAPI, input_metadata: dict, filename: str, expected_output: dict
+):
+    updated_metadata = zenodo_api._add_default_preview_to_metadata(
+        input_metadata, filename
+    )
+    assert updated_metadata == expected_output
 
 
 def test_publish(zenodo_api: ZenodoAPI, httpx_mock: pytest_httpx.HTTPXMock):

--- a/tests/unit/workflows/pipeline_store/test_upload.py
+++ b/tests/unit/workflows/pipeline_store/test_upload.py
@@ -37,7 +37,7 @@ def test_upload(workflow: PipelineUploadWorkflow, mocker: pytest_mock.MockerFixt
     workflow.force = True
     workflow.run_main()
 
-    workflow.zenodo_api.upload_pipeline.assert_called_once()
+    workflow.zenodo_api.upload_record.assert_called_once()
     get_pipeline_metadata.assert_called_once()
     validator.assert_called_once()
 

--- a/tests/unit/workflows/pipeline_store/test_upload.py
+++ b/tests/unit/workflows/pipeline_store/test_upload.py
@@ -8,6 +8,7 @@ import pytest_mock
 from nipoppy.config.pipeline import BasePipelineConfig
 from nipoppy.env import PipelineTypeEnum
 from nipoppy.exceptions import ReturnCode, TerminatedByUserError, WorkflowError
+from nipoppy.layout import DatasetLayout
 from nipoppy.pipeline_validation import _load_pipeline_config_file
 from nipoppy.workflows.pipeline_store.upload import (
     PipelineUploadWorkflow,
@@ -28,7 +29,10 @@ def workflow(mocker: pytest_mock.MockerFixture):
 
 
 def test_upload(workflow: PipelineUploadWorkflow, mocker: pytest_mock.MockerFixture):
-    get_pipeline_metadata = mocker.patch.object(workflow, "_get_pipeline_metadata")
+    metadata = {"metadata": {}}
+    get_pipeline_metadata = mocker.patch.object(
+        workflow, "_get_pipeline_metadata", return_value=metadata
+    )
     validator = mocker.patch(
         "nipoppy.workflows.pipeline_store.upload.check_pipeline_bundle",
     )
@@ -37,7 +41,12 @@ def test_upload(workflow: PipelineUploadWorkflow, mocker: pytest_mock.MockerFixt
     workflow.force = True
     workflow.run_main()
 
-    workflow.zenodo_api.upload_record.assert_called_once()
+    workflow.zenodo_api.upload_record.assert_called_once_with(
+        input_dir=TEST_PIPELINE,
+        record_id=None,
+        metadata=metadata,
+        default_preview_filename=DatasetLayout.fname_pipeline_config,
+    )
     get_pipeline_metadata.assert_called_once()
     validator.assert_called_once()
 


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #659

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Add `_add_default_preview_to_metadata` method to `ZenodoAPI`
- Refactor to only do a single metadata update API call right before publishing the record
- Rename `upload_pipeline` to `upload_record`

Proof that this is working now: https://sandbox.zenodo.org/records/466308
  - `config.json` is the default preview even if there is another file `abc.txt` which would have been the first one otherwise

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [ ] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- ~There is at least one test that would fail under the original bug conditions~


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--904.org.readthedocs.build/en/904/

<!-- readthedocs-preview nipoppy end -->