### PR TITLE
[BUG] Fix Zenodo download integration test failure

### DIFF
--- a/tests/integration/test_zenodo_api.py
+++ b/tests/integration/test_zenodo_api.py
@@ -10,6 +10,7 @@ from ..conftest import datetime_fixture  # noqa F401
 from ..conftest import TEST_PIPELINE
 
 ZENODO_SANDBOX = True
+DEFAULT_PREVIEW = "config.json"
 
 
 @pytest.fixture(scope="function")
@@ -90,6 +91,7 @@ def test_create_new_version(zenodo_api: ZenodoAPI, metadata: dict):
         input_dir=TEST_PIPELINE,
         metadata=metadata,
         record_id=os.environ["ZENODO_ID"],
+        default_preview_filename=DEFAULT_PREVIEW,
     )
 
 
@@ -122,13 +124,12 @@ def test_create_new_version_invalid_record(zenodo_api: ZenodoAPI, metadata: dict
     reason="Requires Zenodo token",
 )
 def test_create_new_record(zenodo_api: ZenodoAPI, metadata: dict):
-    default_preview = "config.json"
 
     zenodo_api.set_authorization(os.environ["ZENODO_TOKEN"])
     doi = zenodo_api.upload_record(
         input_dir=TEST_PIPELINE,
         metadata=metadata,
-        default_preview_filename=default_preview,
+        default_preview_filename=DEFAULT_PREVIEW,
     )
 
     # extract the new record ID from the DOI (e.g. 10.5072/zenodo.123456)
@@ -136,7 +137,7 @@ def test_create_new_record(zenodo_api: ZenodoAPI, metadata: dict):
 
     # verify that the default preview file is set correctly
     response = httpx.get(f"{zenodo_api.api_endpoint}/records/{new_record_id}/files")
-    assert response.json()["default_preview"] == default_preview
+    assert response.json()["default_preview"] == DEFAULT_PREVIEW
 
 
 @pytest.mark.api

--- a/tests/integration/test_zenodo_api.py
+++ b/tests/integration/test_zenodo_api.py
@@ -55,10 +55,11 @@ def test_download_record_files(
     record_id = record_id_prefix + os.environ["ZENODO_ID"]
     zenodo_api.download_record_files(record_id, tmp_path)
 
-    assert len(list(tmp_path.iterdir())) == 6
+    expected_files = list(TEST_PIPELINE.iterdir())
+    assert len(list(tmp_path.iterdir())) == len(expected_files)
 
     # Verify the content of the downloaded files
-    for file in TEST_PIPELINE.iterdir():
+    for file in expected_files:
         assert tmp_path.joinpath(file.name).exists()
         assert tmp_path.joinpath(file.name).read_text() == file.read_text()
 


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #916

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- 

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--917.org.readthedocs.build/en/917/

<!-- readthedocs-preview nipoppy end -->