### PR TITLE
[MAINT] Fix #888 Extract Tar handling to a separate component

### DIFF
--- a/nipoppy/workflows/processing_runner.py
+++ b/nipoppy/workflows/processing_runner.py
@@ -2,16 +2,15 @@
 
 from functools import cached_property
 from pathlib import Path
-from tarfile import is_tarfile
 from typing import Optional
 
 from nipoppy.config.tracker import TrackerConfig
-from nipoppy.env import EXT_TAR, PROGRAM_NAME, StrOrPathLike
-from nipoppy.exceptions import ConfigError, FileOperationError
+from nipoppy.env import PROGRAM_NAME, StrOrPathLike
+from nipoppy.exceptions import FileOperationError
 from nipoppy.logger import get_logger
 from nipoppy.utils import fileops
-from nipoppy.workflows.base import _run_command
 from nipoppy.workflows.runner import Runner
+from nipoppy.workflows.tar_handler import TarHandler
 
 logger = get_logger()
 
@@ -56,6 +55,7 @@ class ProcessingRunner(Runner):
             keep_workdir=keep_workdir,
         )
         self.tar = tar
+        self._tar_handler = TarHandler(dry_run=self.dry_run)
 
     @cached_property
     def dpaths_to_check(self) -> list[Path]:
@@ -71,48 +71,22 @@ class ProcessingRunner(Runner):
 
         Specifically, check that dpath to tar is specified in the tracker config
         """
-        if not self.tar:
-            return
-
-        if self.pipeline_step_config.TRACKER_CONFIG_FILE is None:
-            raise ConfigError(
-                "Tarring requested but there is no tracker config file. "
-                "Specify the TRACKER_CONFIG_FILE field for the pipeline step in "
-                "the global config file, then make sure the PARTICIPANT_SESSION_DIR "
-                "field is specified in the TRACKER_CONFIG_FILE file."
-            )
-        if self.tracker_config.PARTICIPANT_SESSION_DIR is None:
-            raise ConfigError(
-                "Tarring requested but no participant-session directory specified. "
-                "The PARTICIPANT_SESSION_DIR field in the tracker config must set "
-                "in the tracker config file at "
-                f"{self.pipeline_step_config.TRACKER_CONFIG_FILE}"
-            )
+        tracker_config_file = self.pipeline_step_config.TRACKER_CONFIG_FILE
+        participant_session_dir = (
+            self.tracker_config.PARTICIPANT_SESSION_DIR
+            if self.tar and tracker_config_file is not None
+            else None
+        )
+        self._tar_handler.validate_preconditions(
+            tar_requested=self.tar,
+            tracker_config_file=tracker_config_file,
+            participant_session_dir=participant_session_dir,
+        )
 
     def tar_directory(self, dpath: StrOrPathLike) -> Path:
         """Tar a directory and delete it."""
-        dpath = Path(dpath)
-        if not dpath.exists():
-            raise FileOperationError(f"Not tarring {dpath} since it does not exist")
-        if not dpath.is_dir():
-            raise FileOperationError(f"Not tarring {dpath} since it is not a directory")
-
-        tar_flags = "-cvf"
-        fpath_tarred = dpath.with_suffix(EXT_TAR)
-
-        _run_command(
-            f"tar {tar_flags} {fpath_tarred} -C {dpath.parent} {dpath.name}",
-            dry_run=self.dry_run,
-        )
-
-        # make sure that the tarfile was created successfully before removing
-        # original directory
-        if fpath_tarred.exists() and is_tarfile(fpath_tarred):
-            fileops.rm(dpath, dry_run=self.dry_run)
-        else:
-            logger.error(f"Failed to tar {dpath} to {fpath_tarred}")
-
-        return fpath_tarred
+        self._tar_handler.dry_run = self.dry_run
+        return self._tar_handler.tar_directory(dpath)
 
     def get_participants_sessions_to_run(
         self, participant_id: Optional[str], session_id: Optional[str]

--- a/nipoppy/workflows/tar_handler.py
+++ b/nipoppy/workflows/tar_handler.py
@@ -57,7 +57,14 @@ class TarHandler:
         fpath_tarred = dpath.with_suffix(EXT_TAR)
 
         _run_command(
-            f"tar {tar_flags} {fpath_tarred} -C {dpath.parent} {dpath.name}",
+            [
+                "tar",
+                tar_flags,
+                str(fpath_tarred),
+                "-C",
+                str(dpath.parent),
+                dpath.name,
+            ],
             dry_run=self.dry_run,
         )
 

--- a/nipoppy/workflows/tar_handler.py
+++ b/nipoppy/workflows/tar_handler.py
@@ -23,7 +23,7 @@ class TarHandler:
         self,
         tar_requested: bool,
         tracker_config_file: Optional[StrOrPathLike],
-        participant_session_dir: Optional[str] = None,
+        participant_session_dir: Optional[StrOrPathLike] = None,
     ):
         """Validate TAR-related configuration requirements."""
         if not tar_requested:

--- a/nipoppy/workflows/tar_handler.py
+++ b/nipoppy/workflows/tar_handler.py
@@ -40,8 +40,8 @@ class TarHandler:
         if participant_session_dir is None:
             raise ConfigError(
                 "Tarring requested but no participant-session directory specified. "
-                "The PARTICIPANT_SESSION_DIR field in the tracker config must set "
-                "in the tracker config file at "
+                "The PARTICIPANT_SESSION_DIR field must be set in the tracker config "
+                "file at "
                 f"{tracker_config_file}"
             )
 

--- a/nipoppy/workflows/tar_handler.py
+++ b/nipoppy/workflows/tar_handler.py
@@ -14,7 +14,7 @@ logger = get_logger()
 
 
 class TarHandler:
-    """Handle TAR validation and directory archiving."""
+    """Handle tar validation and directory archiving."""
 
     def __init__(self, dry_run: bool = False):
         self.dry_run = dry_run

--- a/nipoppy/workflows/tar_handler.py
+++ b/nipoppy/workflows/tar_handler.py
@@ -1,0 +1,69 @@
+"""TAR-related workflow helper."""
+
+from pathlib import Path
+from tarfile import is_tarfile
+from typing import Optional
+
+from nipoppy.env import EXT_TAR, StrOrPathLike
+from nipoppy.exceptions import ConfigError, FileOperationError
+from nipoppy.logger import get_logger
+from nipoppy.utils import fileops
+from nipoppy.workflows.base import _run_command
+
+logger = get_logger()
+
+
+class TarHandler:
+    """Handle TAR validation and directory archiving."""
+
+    def __init__(self, dry_run: bool = False):
+        self.dry_run = dry_run
+
+    def validate_preconditions(
+        self,
+        tar_requested: bool,
+        tracker_config_file: Optional[StrOrPathLike],
+        participant_session_dir: Optional[str] = None,
+    ):
+        """Validate TAR-related configuration requirements."""
+        if not tar_requested:
+            return
+
+        if tracker_config_file is None:
+            raise ConfigError(
+                "Tarring requested but there is no tracker config file. "
+                "Specify the TRACKER_CONFIG_FILE field for the pipeline step in "
+                "the global config file, then make sure the PARTICIPANT_SESSION_DIR "
+                "field is specified in the TRACKER_CONFIG_FILE file."
+            )
+
+        if participant_session_dir is None:
+            raise ConfigError(
+                "Tarring requested but no participant-session directory specified. "
+                "The PARTICIPANT_SESSION_DIR field in the tracker config must set "
+                "in the tracker config file at "
+                f"{tracker_config_file}"
+            )
+
+    def tar_directory(self, dpath: StrOrPathLike) -> Path:
+        """Tar a directory and delete it."""
+        dpath = Path(dpath)
+        if not dpath.exists():
+            raise FileOperationError(f"Not tarring {dpath} since it does not exist")
+        if not dpath.is_dir():
+            raise FileOperationError(f"Not tarring {dpath} since it is not a directory")
+
+        tar_flags = "-cvf"
+        fpath_tarred = dpath.with_suffix(EXT_TAR)
+
+        _run_command(
+            f"tar {tar_flags} {fpath_tarred} -C {dpath.parent} {dpath.name}",
+            dry_run=self.dry_run,
+        )
+
+        if fpath_tarred.exists() and is_tarfile(fpath_tarred):
+            fileops.rm(dpath, dry_run=self.dry_run)
+        else:
+            logger.error(f"Failed to tar {dpath} to {fpath_tarred}")
+
+        return fpath_tarred

--- a/tests/unit/workflows/test_processing_runner.py
+++ b/tests/unit/workflows/test_processing_runner.py
@@ -3,7 +3,6 @@
 import json
 import re
 import subprocess
-import tarfile
 from pathlib import Path
 
 import pytest
@@ -19,7 +18,7 @@ from nipoppy.container import (
     SingularityHandler,
 )
 from nipoppy.env import ContainerCommandEnum
-from nipoppy.exceptions import ConfigError, FileOperationError
+from nipoppy.exceptions import FileOperationError
 from nipoppy.tabular.curation_status import CurationStatusTable
 from nipoppy.tabular.manifest import Manifest
 from nipoppy.tabular.processing_status import ProcessingStatusTable
@@ -120,11 +119,17 @@ def runner(tmp_path: Path, mocker: pytest_mock.MockFixture) -> ProcessingRunner:
 
 
 def test_run_setup(runner: ProcessingRunner, mocker: pytest_mock.MockFixture):
-    mocked_check_tar_conditions = mocker.patch.object(runner, "_check_tar_conditions")
+    mocked_validate_preconditions = mocker.patch.object(
+        runner._tar_handler, "validate_preconditions"
+    )
     runner.run_setup()
     assert runner.dpath_pipeline_output.exists()
     assert runner.dpath_pipeline_work.exists()
-    mocked_check_tar_conditions.assert_called_once()
+    mocked_validate_preconditions.assert_called_once_with(
+        tar_requested=runner.tar,
+        tracker_config_file=runner.pipeline_step_config.TRACKER_CONFIG_FILE,
+        participant_session_dir=None,
+    )
 
 
 @pytest.mark.parametrize("keep_workdir", [True, False])
@@ -360,107 +365,6 @@ def test_process_container_config_no_bind_cwd(
 def test_process_container_config_no_bindpaths(runner: ProcessingRunner):
     # smoke test for no bind paths
     runner.process_container_config(participant_id="01", session_id="BL")
-
-
-def test_check_tar_conditions_no_tracker_config(runner: ProcessingRunner):
-    runner.tar = True
-    runner.pipeline_step_config.TRACKER_CONFIG_FILE = None
-    with pytest.raises(
-        ConfigError,
-        match="Tarring requested but there is no tracker config file",
-    ):
-        runner._check_tar_conditions()
-
-
-def test_check_tar_conditions_no_dir(runner: ProcessingRunner, tmp_path: Path):
-    runner.tar = True
-    runner.pipeline_step_config.TRACKER_CONFIG_FILE = tmp_path  # not used
-    runner.tracker_config = TrackerConfig(
-        PATHS=[tmp_path], PARTICIPANT_SESSION_DIR=None
-    )
-    with pytest.raises(
-        ConfigError,
-        match="Tarring requested but no participant-session directory specified",
-    ):
-        runner._check_tar_conditions()
-
-
-def test_check_tar_conditions_no_tar(runner: ProcessingRunner):
-    runner.tar = False
-    runner._check_tar_conditions()
-
-
-@pytest.mark.parametrize("dpath_type", [Path, str])
-def test_tar_directory(tmp_path: Path, dpath_type):
-    # create dummy files to tar
-    dpath_to_tar = tmp_path / "my_data"
-    fpaths_to_tar = [
-        dpath_to_tar / "dir1" / "file1.txt",
-        dpath_to_tar / "file2.txt",
-    ]
-    for fpath in fpaths_to_tar:
-        fpath.parent.mkdir(parents=True, exist_ok=True)
-        fpath.touch()
-
-    runner = ProcessingRunner(
-        dpath_root=tmp_path / "my_dataset",
-        pipeline_name="dummy_pipeline",
-        pipeline_version="1.0.0",
-    )
-    fpath_tarred = runner.tar_directory(dpath_type(dpath_to_tar))
-
-    assert fpath_tarred == dpath_to_tar.with_suffix(".tar")
-    assert fpath_tarred.exists()
-    assert fpath_tarred.is_file()
-
-    with tarfile.open(fpath_tarred, "r") as tar:
-        tarred_files = {
-            tmp_path / tarred.name for tarred in tar.getmembers() if tarred.isfile()
-        }
-    assert tarred_files == set(fpaths_to_tar)
-
-    assert not dpath_to_tar.exists()
-
-
-@pytest.mark.no_xdist
-def test_tar_directory_failure(
-    runner: ProcessingRunner,
-    tmp_path: Path,
-    mocker: pytest_mock.MockFixture,
-    caplog: pytest.LogCaptureFixture,
-):
-    dpath_to_tar = tmp_path / "my_data"
-    fpath_to_tar = dpath_to_tar / "file.txt"
-    fpath_to_tar.parent.mkdir(parents=True)
-    fpath_to_tar.touch()
-
-    mocked_is_tarfile = mocker.patch(
-        "nipoppy.workflows.tar_handler.is_tarfile", return_value=False
-    )
-
-    fpath_tarred = runner.tar_directory(dpath_to_tar)
-
-    assert fpath_tarred.exists()
-    mocked_is_tarfile.assert_called_once()
-
-    assert f"Failed to tar {dpath_to_tar}" in caplog.text
-
-
-def test_tar_directory_warning_not_found(runner: ProcessingRunner):
-    with pytest.raises(
-        FileOperationError, match="Not tarring .* since it does not exist"
-    ):
-        runner.tar_directory("invalid_path")
-
-
-def test_tar_directory_warning_not_dir(runner: ProcessingRunner, tmp_path: Path):
-    fpath_to_tar = tmp_path / "file.txt"
-    fpath_to_tar.touch()
-
-    with pytest.raises(
-        FileOperationError, match="Not tarring .* since it is not a directory"
-    ):
-        runner.tar_directory(fpath_to_tar)
 
 
 @pytest.mark.parametrize(
@@ -756,8 +660,10 @@ def test_run_single_tar(
         side_effect=None if boutiques_success else RuntimeError(exception_message),
     )
 
-    # mock tar_directory method (will check if/how this is called)
-    mocked_tar_directory = mocker.patch.object(runner, "tar_directory")
+    # mock TarHandler method to verify tar_directory delegation path
+    mocked_tar_handler_tar_directory = mocker.patch.object(
+        runner._tar_handler, "tar_directory"
+    )
 
     participant_id = "01"
     session_id = "1"
@@ -774,11 +680,11 @@ def test_run_single_tar(
             raise exception
 
     if tar and boutiques_success:
-        mocked_tar_directory.assert_called_once_with(
+        mocked_tar_handler_tar_directory.assert_called_once_with(
             runner.dpath_pipeline_output / f"{participant_id}_ses-{session_id}"
         )
     else:
-        mocked_tar_directory.assert_not_called()
+        mocked_tar_handler_tar_directory.assert_not_called()
 
 
 def test_run_missing_container_raises_error(runner: ProcessingRunner):

--- a/tests/unit/workflows/test_processing_runner.py
+++ b/tests/unit/workflows/test_processing_runner.py
@@ -435,7 +435,7 @@ def test_tar_directory_failure(
     fpath_to_tar.touch()
 
     mocked_is_tarfile = mocker.patch(
-        "nipoppy.workflows.processing_runner.is_tarfile", return_value=False
+        "nipoppy.workflows.tar_handler.is_tarfile", return_value=False
     )
 
     fpath_tarred = runner.tar_directory(dpath_to_tar)

--- a/tests/unit/workflows/test_tar_handler.py
+++ b/tests/unit/workflows/test_tar_handler.py
@@ -50,7 +50,7 @@ def test_validate_preconditions_no_tar_requested(tar_handler: TarHandler):
 
 
 @pytest.mark.parametrize("dpath_type", [Path, str])
-def test_tar_directory(tmp_path: Path, dpath_type):
+def test_tar_directory(tar_handler: TarHandler, tmp_path: Path, dpath_type):
     dpath_to_tar = tmp_path / "my_data"
     fpaths_to_tar = [
         dpath_to_tar / "dir1" / "file1.txt",
@@ -60,7 +60,7 @@ def test_tar_directory(tmp_path: Path, dpath_type):
         fpath.parent.mkdir(parents=True, exist_ok=True)
         fpath.touch()
 
-    fpath_tarred = TarHandler().tar_directory(dpath_type(dpath_to_tar))
+    fpath_tarred = tar_handler.tar_directory(dpath_type(dpath_to_tar))
 
     assert fpath_tarred == dpath_to_tar.with_suffix(".tar")
     assert fpath_tarred.exists()

--- a/tests/unit/workflows/test_tar_handler.py
+++ b/tests/unit/workflows/test_tar_handler.py
@@ -1,0 +1,114 @@
+"""Tests for TAR workflow helper."""
+
+import tarfile
+from pathlib import Path
+
+import pytest
+import pytest_mock
+
+from nipoppy.exceptions import ConfigError, FileOperationError
+from nipoppy.workflows.tar_handler import TarHandler
+
+
+@pytest.fixture
+def tar_handler() -> TarHandler:
+    return TarHandler()
+
+
+def test_validate_preconditions_no_tracker_config(tar_handler: TarHandler):
+    with pytest.raises(
+        ConfigError,
+        match="Tarring requested but there is no tracker config file",
+    ):
+        tar_handler.validate_preconditions(
+            tar_requested=True,
+            tracker_config_file=None,
+            participant_session_dir="sub-01/ses-1",
+        )
+
+
+def test_validate_preconditions_no_participant_session_dir(
+    tar_handler: TarHandler, tmp_path: Path
+):
+    with pytest.raises(
+        ConfigError,
+        match="Tarring requested but no participant-session directory specified",
+    ):
+        tar_handler.validate_preconditions(
+            tar_requested=True,
+            tracker_config_file=tmp_path / "tracker_config.json",
+            participant_session_dir=None,
+        )
+
+
+def test_validate_preconditions_no_tar_requested(tar_handler: TarHandler):
+    tar_handler.validate_preconditions(
+        tar_requested=False,
+        tracker_config_file=None,
+        participant_session_dir=None,
+    )
+
+
+@pytest.mark.parametrize("dpath_type", [Path, str])
+def test_tar_directory(tmp_path: Path, dpath_type):
+    dpath_to_tar = tmp_path / "my_data"
+    fpaths_to_tar = [
+        dpath_to_tar / "dir1" / "file1.txt",
+        dpath_to_tar / "file2.txt",
+    ]
+    for fpath in fpaths_to_tar:
+        fpath.parent.mkdir(parents=True, exist_ok=True)
+        fpath.touch()
+
+    fpath_tarred = TarHandler().tar_directory(dpath_type(dpath_to_tar))
+
+    assert fpath_tarred == dpath_to_tar.with_suffix(".tar")
+    assert fpath_tarred.exists()
+    assert fpath_tarred.is_file()
+
+    with tarfile.open(fpath_tarred, "r") as tar:
+        tarred_files = {
+            tmp_path / tarred.name for tarred in tar.getmembers() if tarred.isfile()
+        }
+    assert tarred_files == set(fpaths_to_tar)
+    assert not dpath_to_tar.exists()
+
+
+@pytest.mark.no_xdist
+def test_tar_directory_failure(
+    tar_handler: TarHandler,
+    tmp_path: Path,
+    mocker: pytest_mock.MockFixture,
+    caplog: pytest.LogCaptureFixture,
+):
+    dpath_to_tar = tmp_path / "my_data"
+    fpath_to_tar = dpath_to_tar / "file.txt"
+    fpath_to_tar.parent.mkdir(parents=True)
+    fpath_to_tar.touch()
+
+    mocked_is_tarfile = mocker.patch(
+        "nipoppy.workflows.tar_handler.is_tarfile", return_value=False
+    )
+
+    fpath_tarred = tar_handler.tar_directory(dpath_to_tar)
+
+    assert fpath_tarred.exists()
+    mocked_is_tarfile.assert_called_once()
+    assert f"Failed to tar {dpath_to_tar}" in caplog.text
+
+
+def test_tar_directory_warning_not_found(tar_handler: TarHandler):
+    with pytest.raises(
+        FileOperationError, match="Not tarring .* since it does not exist"
+    ):
+        tar_handler.tar_directory("invalid_path")
+
+
+def test_tar_directory_warning_not_dir(tar_handler: TarHandler, tmp_path: Path):
+    fpath_to_tar = tmp_path / "file.txt"
+    fpath_to_tar.touch()
+
+    with pytest.raises(
+        FileOperationError, match="Not tarring .* since it is not a directory"
+    ):
+        tar_handler.tar_directory(fpath_to_tar)


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #888

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Move tar logic from ProcessingRunner to a new module (`nipoppy.workflows.tar_handler`). Note: this would be moved to new location in https://github.com/nipoppy/nipoppy/issues/922

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--953.org.readthedocs.build/en/953/

<!-- readthedocs-preview nipoppy end -->