### PR TITLE
[ENH] Expose "length" and number of unique participants in a Study

### DIFF
--- a/nipoppy/study.py
+++ b/nipoppy/study.py
@@ -44,6 +44,10 @@ class Study(Base):
         self.layout = layout
         self.verbose = verbose
 
+    def __len__(self):
+        """Get the number of unique participant-visit combinations in the study."""
+        return len(self.manifest)
+
     @cached_property
     def config(self) -> Config:
         """The main configuration object."""

--- a/nipoppy/study.py
+++ b/nipoppy/study.py
@@ -40,7 +40,8 @@ class Study(Base):
         """Get the number of unique participant-visit combinations in the study."""
         return len(self.manifest)
 
-    def get_n_participants(self) -> int:
+    @property
+    def n_unique_participants(self) -> int:
         """Get the number of unique participants in the study."""
         return len(set(self.manifest.get_participants()))
 

--- a/nipoppy/study.py
+++ b/nipoppy/study.py
@@ -40,11 +40,6 @@ class Study(Base):
         """Get the number of unique participant-visit combinations in the study."""
         return len(self.manifest)
 
-    @property
-    def n_unique_participants(self) -> int:
-        """Get the number of unique participants in the study."""
-        return len(self.manifest.get_unique_participants())
-
     @cached_property
     def config(self) -> Config:
         """The main configuration object."""

--- a/nipoppy/study.py
+++ b/nipoppy/study.py
@@ -43,7 +43,7 @@ class Study(Base):
     @property
     def n_unique_participants(self) -> int:
         """Get the number of unique participants in the study."""
-        return len(set(self.manifest.get_participants()))
+        return len(self.manifest.get_unique_participants())
 
     @cached_property
     def config(self) -> Config:

--- a/nipoppy/study.py
+++ b/nipoppy/study.py
@@ -40,7 +40,7 @@ class Study(Base):
         """Get the number of unique participant-visit combinations in the study."""
         return len(self.manifest)
 
-    def get_n_unique_participants(self) -> int:
+    def get_n_participants(self) -> int:
         """Get the number of unique participants in the study."""
         return len(set(self.manifest.get_participants()))
 

--- a/nipoppy/study.py
+++ b/nipoppy/study.py
@@ -40,6 +40,10 @@ class Study(Base):
         """Get the number of unique participant-visit combinations in the study."""
         return len(self.manifest)
 
+    def get_n_unique_participants(self) -> int:
+        """Get the number of unique participants in the study."""
+        return len(set(self.manifest.get_participants()))
+
     @cached_property
     def config(self) -> Config:
         """The main configuration object."""

--- a/nipoppy/tabular/manifest.py
+++ b/nipoppy/tabular/manifest.py
@@ -127,10 +127,6 @@ class Manifest(BaseTabular):
             return manifest[manifest[self.col_session_id] == session_id]
         return manifest
 
-    def get_unique_participants(self) -> list[str]:
-        """Get unique participant IDs."""
-        return self.loc[:, self.col_participant_id].drop_duplicates().tolist()
-
     def get_participants_sessions(
         self, participant_id: Optional[str] = None, session_id: Optional[str] = None
     ):

--- a/nipoppy/tabular/manifest.py
+++ b/nipoppy/tabular/manifest.py
@@ -127,9 +127,9 @@ class Manifest(BaseTabular):
             return manifest[manifest[self.col_session_id] == session_id]
         return manifest
 
-    def get_participants(self) -> list[str]:
-        """Get participant IDs."""
-        return self.loc[:, self.col_participant_id].to_list()
+    def get_unique_participants(self) -> list[str]:
+        """Get unique participant IDs."""
+        return self.loc[:, self.col_participant_id].drop_duplicates().tolist()
 
     def get_participants_sessions(
         self, participant_id: Optional[str] = None, session_id: Optional[str] = None

--- a/nipoppy/tabular/manifest.py
+++ b/nipoppy/tabular/manifest.py
@@ -127,6 +127,10 @@ class Manifest(BaseTabular):
             return manifest[manifest[self.col_session_id] == session_id]
         return manifest
 
+    def get_participants(self) -> list[str]:
+        """Get participant IDs."""
+        return self.loc[:, self.col_participant_id].to_list()
+
     def get_participants_sessions(
         self, participant_id: Optional[str] = None, session_id: Optional[str] = None
     ):

--- a/tests/unit/tabular/test_manifest.py
+++ b/tests/unit/tabular/test_manifest.py
@@ -123,24 +123,6 @@ def test_get_imaging_subset(data, session_id, expected_count):
 
 
 @pytest.mark.parametrize(
-    "participant_ids,unique_participant_ids",
-    [
-        (["01", "01", "01", "02", "02", "03", "04"], ["01", "02", "03", "04"]),
-        (["03", "02", "01"], ["03", "02", "01"]),
-    ],
-)
-def test_get_unique_participants(participant_ids, unique_participant_ids):
-    data = {
-        "participant_id": participant_ids,
-        "visit_id": [str(i) for i in range(len(participant_ids))],
-        "session_id": [str(i) for i in range(len(participant_ids))],
-        "datatype": [["anat"] for _ in participant_ids],
-    }
-    manifest = Manifest(data)
-    assert manifest.get_unique_participants() == unique_participant_ids
-
-
-@pytest.mark.parametrize(
     "participant_id,session_id,expected_count",
     [
         (None, None, 6),

--- a/tests/unit/tabular/test_manifest.py
+++ b/tests/unit/tabular/test_manifest.py
@@ -154,31 +154,29 @@ def test_get_participants(participant_ids):
         ("03", "ses-BL", 1),
     ],
 )
-def get_participants_sessions(participant_id, session_id, expected_count):
-    data = (
-        {
-            "participant_id": ["01", "01", "01", "02", "02", "03", "04"],
-            "visit": ["BL", "M12", "M24", "BL", "M12", "BL", "SC"],
-            "session_id": [
-                "ses-BL",
-                "ses-M12",
-                "ses-M24",
-                "ses-BL",
-                "ses-M12",
-                "ses-BL",
-                None,
-            ],
-            "datatype": [
-                ["anat"],
-                ["anat"],
-                ["anat"],
-                ["anat"],
-                ["anat"],
-                ["anat"],
-                [],
-            ],
-        },
-    )
+def test_get_participants_sessions(participant_id, session_id, expected_count):
+    data = {
+        "participant_id": ["01", "01", "01", "02", "02", "03", "04"],
+        "visit_id": ["BL", "M12", "M24", "BL", "M12", "BL", "SC"],
+        "session_id": [
+            "ses-BL",
+            "ses-M12",
+            "ses-M24",
+            "ses-BL",
+            "ses-M12",
+            "ses-BL",
+            None,
+        ],
+        "datatype": [
+            ["anat"],
+            ["anat"],
+            ["anat"],
+            ["anat"],
+            ["anat"],
+            ["anat"],
+            [],
+        ],
+    }
     manifest = Manifest(data)
     count = 0
     for _ in manifest.get_participants_sessions(

--- a/tests/unit/tabular/test_manifest.py
+++ b/tests/unit/tabular/test_manifest.py
@@ -123,6 +123,23 @@ def test_get_imaging_subset(data, session_id, expected_count):
 
 
 @pytest.mark.parametrize(
+    "participant_ids",
+    [
+        ["01", "01", "01", "02", "02", "03", "04"],
+    ],
+)
+def test_get_participants(participant_ids):
+    data = {
+        "participant_id": participant_ids,
+        "visit": [str(i) for i in range(len(participant_ids))],
+        "session_id": [str(i) for i in range(len(participant_ids))],
+        "datatype": [["anat"] for _ in participant_ids],
+    }
+    manifest = Manifest(data)
+    assert manifest.get_participants() == participant_ids
+
+
+@pytest.mark.parametrize(
     "participant_id,session_id,expected_count",
     [
         (None, None, 6),

--- a/tests/unit/tabular/test_manifest.py
+++ b/tests/unit/tabular/test_manifest.py
@@ -123,20 +123,21 @@ def test_get_imaging_subset(data, session_id, expected_count):
 
 
 @pytest.mark.parametrize(
-    "participant_ids",
+    "participant_ids,unique_participant_ids",
     [
-        ["01", "01", "01", "02", "02", "03", "04"],
+        (["01", "01", "01", "02", "02", "03", "04"], ["01", "02", "03", "04"]),
+        (["03", "02", "01"], ["03", "02", "01"]),
     ],
 )
-def test_get_participants(participant_ids):
+def test_get_unique_participants(participant_ids, unique_participant_ids):
     data = {
         "participant_id": participant_ids,
-        "visit": [str(i) for i in range(len(participant_ids))],
+        "visit_id": [str(i) for i in range(len(participant_ids))],
         "session_id": [str(i) for i in range(len(participant_ids))],
         "datatype": [["anat"] for _ in participant_ids],
     }
     manifest = Manifest(data)
-    assert manifest.get_participants() == participant_ids
+    assert manifest.get_unique_participants() == unique_participant_ids
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_study.py
+++ b/tests/unit/test_study.py
@@ -14,9 +14,9 @@ def test_len(study: Study, mocker: pytest_mock.MockFixture):
     assert len(study) == 5
 
 
-def test_get_n_participants(study: Study):
+def test_n_unique_participants(study: Study):
     study.manifest = Manifest.load(DPATH_TEST_DATA / "manifest1.tsv")
-    assert study.get_n_participants() == 2
+    assert study.n_unique_participants == 2
 
 
 def test_config(study: Study, mocker: pytest_mock.MockFixture):

--- a/tests/unit/test_study.py
+++ b/tests/unit/test_study.py
@@ -4,13 +4,19 @@ import pytest
 import pytest_mock
 
 from nipoppy.study import Study
-from tests.conftest import get_config
+from nipoppy.tabular.manifest import Manifest
+from tests.conftest import DPATH_TEST_DATA, get_config
 
 
 def test_len(study: Study, mocker: pytest_mock.MockFixture):
     study.manifest = mocker.MagicMock()
     study.manifest.__len__.return_value = 5
     assert len(study) == 5
+
+
+def test_get_n_unique_participants(study: Study):
+    study.manifest = Manifest.load(DPATH_TEST_DATA / "manifest1.tsv")
+    assert study.get_n_unique_participants() == 2
 
 
 def test_config(study: Study, mocker: pytest_mock.MockFixture):

--- a/tests/unit/test_study.py
+++ b/tests/unit/test_study.py
@@ -14,9 +14,9 @@ def test_len(study: Study, mocker: pytest_mock.MockFixture):
     assert len(study) == 5
 
 
-def test_get_n_unique_participants(study: Study):
+def test_get_n_participants(study: Study):
     study.manifest = Manifest.load(DPATH_TEST_DATA / "manifest1.tsv")
-    assert study.get_n_unique_participants() == 2
+    assert study.get_n_participants() == 2
 
 
 def test_config(study: Study, mocker: pytest_mock.MockFixture):

--- a/tests/unit/test_study.py
+++ b/tests/unit/test_study.py
@@ -4,19 +4,13 @@ import pytest
 import pytest_mock
 
 from nipoppy.study import Study
-from nipoppy.tabular.manifest import Manifest
-from tests.conftest import DPATH_TEST_DATA, get_config
+from tests.conftest import get_config
 
 
 def test_len(study: Study, mocker: pytest_mock.MockFixture):
     study.manifest = mocker.MagicMock()
     study.manifest.__len__.return_value = 5
     assert len(study) == 5
-
-
-def test_n_unique_participants(study: Study):
-    study.manifest = Manifest.load(DPATH_TEST_DATA / "manifest1.tsv")
-    assert study.n_unique_participants == 2
 
 
 def test_config(study: Study, mocker: pytest_mock.MockFixture):

--- a/tests/unit/test_study.py
+++ b/tests/unit/test_study.py
@@ -7,6 +7,12 @@ from nipoppy.study import Study
 from tests.conftest import get_config
 
 
+def test_len(study: Study, mocker: pytest_mock.MockFixture):
+    study.manifest = mocker.MagicMock()
+    study.manifest.__len__.return_value = 5
+    assert len(study) == 5
+
+
 def test_config(study: Study, mocker: pytest_mock.MockFixture):
     config = get_config(dicom_dir_map_file="[[NIPOPPY_DPATH_ROOT]]")
     mocked_load = mocker.patch("nipoppy.study.Config.load", return_value=config)


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #954

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Define `len(Study(...))` to be the length of the manifest file
- Add `Study.get_n_participants()` (and `Manifest.get_participants()`)
    - Not sure about this one: it feels restrictive since it would be more useful to have the full list of participant IDs instead, but then we would have to make the manifest public and we don't want to do that yet. So maybe it's best to remove this for now and reconsider later. Anyway for Fed-BioMed's `NipoppyDataset` the `__len__` is enough. Thoughts @mathdugre?

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--979.org.readthedocs.build/en/979/

<!-- readthedocs-preview nipoppy end -->