### PR TITLE
[DOC] fix shifted emphasize-lines in hpc_scheduler guide

### DIFF
--- a/docs/source/how_to_guides/parallelization/hpc_scheduler.md
+++ b/docs/source/how_to_guides/parallelization/hpc_scheduler.md
@@ -21,7 +21,7 @@ The default global configuration file has two {term}`HPC`-related fields that sh
 ---
 linenos: True
 language: json
-emphasize-lines: 4,16-25
+emphasize-lines: 5,18-27
 ---
 ```
 
@@ -70,7 +70,7 @@ You will also need to add an `"HPC_CONFIG_FILE"` field for each step in pipeline
 linenos: True
 language: json
 lines: 12-18
-emphasize-lines: 5
+emphasize-lines: 6
 ---
 ```
 ````


### PR DESCRIPTION
closes #929

## what

two `emphasize-lines` specs in `docs/source/how_to_guides/parallelization/hpc_scheduler.md` no longer lined up with the json content they pointed at:

**sample_global_config.json include (line 24)**
- was: `emphasize-lines: 4,16-25`
- now: `emphasize-lines: 5,18-27`
- line 4 of the json is `[[NIPOPPY_DPATH_CONTAINERS]]`, not `[[HPC_ACCOUNT_NAME]]` which is what the section heading refers to (that's line 5). lines 16-25 covered the closing braces of `CONTAINER_CONFIG` plus the start of `HPC_PREAMBLE`; the full preamble block is actually lines 18-27.

**config-extraction.json include (line 73)**
- was: `emphasize-lines: 5`
- now: `emphasize-lines: 6`
- with `lines: 12-18`, relative line 5 is `ANALYSIS_LEVEL`. the paragraph above the include explains `HPC_CONFIG_FILE`, which is relative line 6.

## what i did not change

i checked the other `emphasize-lines` usages that reference global/pipeline config examples (`docker/index.md`, `tracking/index.md`, `pipeline_create/index.md`, `mriqc_from_bids/index.md`) and they still match their json content, so i left them alone to keep the PR minimal.

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--987.org.readthedocs.build/en/987/

<!-- readthedocs-preview nipoppy end -->
