### PR TITLE
[MAINT] Extract tar dir function to fileops module

### DIFF
--- a/nipoppy/utils/fileops.py
+++ b/nipoppy/utils/fileops.py
@@ -2,13 +2,13 @@
 
 import errno
 import shutil
-import subprocess
 from pathlib import Path
 from tarfile import is_tarfile
 
 from nipoppy.env import EXT_TAR
 from nipoppy.exceptions import FileOperationError
 from nipoppy.logger import get_logger
+from nipoppy.utils.subprocess_runner import run_command
 
 logger = get_logger()
 
@@ -102,11 +102,12 @@ def tar_directory(dpath: Path, dry_run: bool = False) -> Path:
 
     fpath_tarred = dpath.with_suffix(EXT_TAR)
     logger.debug(f"Tarring {dpath} to {fpath_tarred}")
+    run_command(
+        ["tar", "-cvf", str(fpath_tarred), "-C", str(dpath.parent), dpath.name],
+        check=True,
+        dry_run=dry_run,
+    )
     if not dry_run:
-        subprocess.run(
-            ["tar", "-cvf", str(fpath_tarred), "-C", str(dpath.parent), dpath.name],
-            check=True,
-        )
         if not (fpath_tarred.exists() and is_tarfile(fpath_tarred)):
             raise FileOperationError(f"Failed to tar {dpath} to {fpath_tarred}")
 

--- a/nipoppy/utils/fileops.py
+++ b/nipoppy/utils/fileops.py
@@ -2,8 +2,11 @@
 
 import errno
 import shutil
+import subprocess
 from pathlib import Path
+from tarfile import is_tarfile
 
+from nipoppy.env import EXT_TAR
 from nipoppy.exceptions import FileOperationError
 from nipoppy.logger import get_logger
 
@@ -68,6 +71,46 @@ def _ignore_oserror_empty_dir(function, path, excinfo):
     if isinstance(exception, OSError) and exception.errno == errno.ENOTEMPTY:
         return
     raise exception
+
+
+def tar_directory(dpath: Path, dry_run: bool = False) -> Path:
+    """Create a tarball of a directory.
+
+    The tarball is created in the same parent directory as the original directory,
+    with the same name and a .tar extension.
+
+    The original directory is NOT removed after tarring. The caller is responsible for
+    removing the original directory if desired.
+
+    Parameters
+    ----------
+    dpath: Path
+        Path to the directory to tar.
+    dry_run: bool, optional
+        If True, do not actually perform the tarring operation, just log it. Default is
+        False.
+
+    Returns
+    -------
+    Path
+        Path to the tarball.
+    """
+    if not dpath.exists():
+        raise FileOperationError(f"Dir does not exist: {dpath}")
+    if not dpath.is_dir():
+        raise FileOperationError(f"Cannot tar non-directory: {dpath}")
+
+    fpath_tarred = dpath.with_suffix(EXT_TAR)
+    logger.debug(f"Tarring {dpath} to {fpath_tarred}")
+    if not dry_run:
+        subprocess.run(
+            ["tar", "-cvf", str(fpath_tarred), "-C", str(dpath.parent), dpath.name],
+            check=True,
+        )
+        if not (fpath_tarred.exists() and is_tarfile(fpath_tarred)):
+            logger.error(f"Failed to tar {dpath} to {fpath_tarred}")
+
+    return fpath_tarred
 
 
 def rm(path: Path, dry_run=False):

--- a/nipoppy/utils/fileops.py
+++ b/nipoppy/utils/fileops.py
@@ -108,7 +108,7 @@ def tar_directory(dpath: Path, dry_run: bool = False) -> Path:
             check=True,
         )
         if not (fpath_tarred.exists() and is_tarfile(fpath_tarred)):
-            logger.error(f"Failed to tar {dpath} to {fpath_tarred}")
+            raise FileOperationError(f"Failed to tar {dpath} to {fpath_tarred}")
 
     return fpath_tarred
 

--- a/nipoppy/utils/fileops.py
+++ b/nipoppy/utils/fileops.py
@@ -96,7 +96,7 @@ def tar_directory(dpath: Path, dry_run: bool = False) -> Path:
         Path to the tarball.
     """
     if not dpath.exists():
-        raise FileOperationError(f"Dir does not exist: {dpath}")
+        raise FileOperationError(f"Directory does not exist: {dpath}")
     if not dpath.is_dir():
         raise FileOperationError(f"Cannot tar non-directory: {dpath}")
 

--- a/nipoppy/utils/fileops.py
+++ b/nipoppy/utils/fileops.py
@@ -107,9 +107,8 @@ def tar_directory(dpath: Path, dry_run: bool = False) -> Path:
         check=True,
         dry_run=dry_run,
     )
-    if not dry_run:
-        if not (fpath_tarred.exists() and is_tarfile(fpath_tarred)):
-            raise FileOperationError(f"Failed to tar {dpath} to {fpath_tarred}")
+    if not dry_run and not (fpath_tarred.exists() and is_tarfile(fpath_tarred)):
+        raise FileOperationError(f"Failed to tar {dpath} to {fpath_tarred}")
 
     return fpath_tarred
 

--- a/nipoppy/utils/subprocess_runner.py
+++ b/nipoppy/utils/subprocess_runner.py
@@ -1,0 +1,147 @@
+"""Subprocess runner utilities with streaming log output and dry-run support."""
+
+from __future__ import annotations
+
+import logging
+import shlex
+import subprocess
+from typing import Protocol, Sequence
+
+from nipoppy.logger import get_logger
+
+logger = get_logger()
+
+
+class LogPrefix:
+    """Prefixes for logging subprocess output."""
+
+    RUN = "[RUN]"
+    RUN_STDOUT = "[RUN STDOUT]"
+    RUN_STDERR = "[RUN STDERR]"
+
+
+def _log_command(command: str):
+    """Write a command to the log with a special prefix."""
+    # using extra={"markup": False} in case the command contains substrings
+    # that would be interpreted as closing tags by the RichHandler
+    logger.info(f"{LogPrefix.RUN} {command}", extra={"markup": False})
+
+
+class CommandRunner(Protocol):
+    """Protocol for functions that run commands, used for strategy injection."""
+
+    def __call__(
+        self,
+        command_or_args: Sequence[str] | str,
+        /,
+        *,
+        check: bool = True,
+        quiet: bool = False,
+        dry_run: bool = False,
+    ) -> subprocess.Popen[str] | str:
+        """Run a command in a subprocess, with logging and dry-run support."""
+        ...
+
+
+def run_command(
+    command_or_args: Sequence[str] | str,
+    /,
+    *,
+    check: bool = True,
+    quiet: bool = False,
+    dry_run: bool = False,
+    **kwargs,
+) -> subprocess.Popen[str] | str:
+    """Run a command in a subprocess.
+
+    The command's stdout and stderr outputs are streamed to the log
+    line-by-line (with special prefixes) as the process runs.
+
+    If in "dry run" mode, the command is not executed, and the function returns
+    the command string. Otherwise, the :class:`subprocess.Popen` object is
+    returned once the process has terminated.
+
+    Parameters
+    ----------
+    command_or_args : Sequence[str] | str
+        The command to run.
+    check : bool, optional
+        If True, raise an error if the process exits with a non-zero code,
+        by default True.
+    quiet : bool, optional
+        If True, do not log the command, by default False.
+    dry_run : bool, optional
+        If True, do not execute the command, by default False.
+    **kwargs
+        Passed to :class:`subprocess.Popen`.
+
+    Returns
+    -------
+    subprocess.Popen or str
+    """
+
+    def process_output(output_source, log_prefix: str, log_level=logging.INFO):
+        """Consume lines from an IO stream and log them."""
+        for line in output_source:
+            line = line.strip("\n")
+            # using extra={"markup": False} in case the output contains substrings
+            # that would be interpreted as closing tags by the RichHandler
+            logger.log(
+                level=log_level,
+                msg=f"{log_prefix} {line}",
+                extra={"markup": False},
+            )
+
+    def drain_process(process: subprocess.Popen[str]):
+        """Read lines from the process's stdout and stderr and log them."""
+        process_output(
+            process.stdout,
+            LogPrefix.RUN_STDOUT,
+        )
+        process_output(
+            process.stderr,
+            LogPrefix.RUN_STDERR,
+            log_level=logging.ERROR,
+        )
+
+    # build command string
+    if not isinstance(command_or_args, str):
+        args = [str(arg) for arg in command_or_args]
+        command = shlex.join(args)
+    else:
+        command = command_or_args
+        args = shlex.split(command)
+
+    # only pass a single string if shell is True
+    if not kwargs.get("shell"):
+        command_or_args = args
+
+    if not quiet:
+        _log_command(command)
+
+    if not dry_run:
+        process: subprocess.Popen[str] = subprocess.Popen(
+            command_or_args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            **kwargs,
+        )
+
+        while process.poll() is None:
+            drain_process(process)
+
+        # final drain: the poll() loop can exit before the last lines written
+        # just prior to process termination are read, so flush any remaining
+        # buffered output now that the process has exited.
+        drain_process(process)
+
+        if check and process.returncode != 0:
+            raise subprocess.CalledProcessError(process.returncode, command)
+
+        run_output = process
+
+    else:
+        run_output = command
+
+    return run_output

--- a/nipoppy/utils/subprocess_runner.py
+++ b/nipoppy/utils/subprocess_runner.py
@@ -104,44 +104,46 @@ def run_command(
             log_level=logging.ERROR,
         )
 
-    # build command string
-    if not isinstance(command_or_args, str):
-        args = [str(arg) for arg in command_or_args]
-        command = shlex.join(args)
-    else:
-        command = command_or_args
-        args = shlex.split(command)
+    def build_cmd(command_or_args: Sequence[str] | str) -> tuple[str, list[str]]:
+        # build command string
+        if isinstance(command_or_args, str):
+            command = command_or_args
+            args = shlex.split(command)
+        else:
+            args = [str(arg) for arg in command_or_args]
+            command = shlex.join(args)
+
+        return command, args
+
+    command, args = build_cmd(command_or_args)
+
+    if not quiet:
+        _log_command(command)
+
+    if dry_run:
+        return command
 
     # only pass a single string if shell is True
     if not kwargs.get("shell"):
         command_or_args = args
 
-    if not quiet:
-        _log_command(command)
+    process: subprocess.Popen[str] = subprocess.Popen(
+        command_or_args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        **kwargs,
+    )
 
-    if not dry_run:
-        process: subprocess.Popen[str] = subprocess.Popen(
-            command_or_args,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            **kwargs,
-        )
-
-        while process.poll() is None:
-            drain_process(process)
-
-        # final drain: the poll() loop can exit before the last lines written
-        # just prior to process termination are read, so flush any remaining
-        # buffered output now that the process has exited.
+    while process.poll() is None:
         drain_process(process)
 
-        if check and process.returncode != 0:
-            raise subprocess.CalledProcessError(process.returncode, command)
+    # final drain: the poll() loop can exit before the last lines written
+    # just prior to process termination are read, so flush any remaining
+    # buffered output now that the process has exited.
+    drain_process(process)
 
-        run_output = process
+    if check and process.returncode != 0:
+        raise subprocess.CalledProcessError(process.returncode, command)
 
-    else:
-        run_output = command
-
-    return run_output
+    return process

--- a/nipoppy/utils/subprocess_runner.py
+++ b/nipoppy/utils/subprocess_runner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import shlex
 import subprocess
-from typing import Protocol, Sequence
+from typing import Any, Protocol, Sequence, TextIO
 
 from nipoppy.logger import get_logger
 
@@ -20,11 +20,91 @@ class LogPrefix:
     RUN_STDERR = "[RUN STDERR]"
 
 
-def _log_command(command: str):
+def _log_command(command: str) -> None:
     """Write a command to the log with a special prefix."""
     # using extra={"markup": False} in case the command contains substrings
     # that would be interpreted as closing tags by the RichHandler
     logger.info(f"{LogPrefix.RUN} {command}", extra={"markup": False})
+
+
+def _log_output(
+    output_source: TextIO,
+    log_prefix: str,
+    log_level: int = logging.INFO,
+) -> None:
+    """Consume lines from an IO stream and log them."""
+    for line in output_source:
+        line = line.strip("\n")
+        # using extra={"markup": False} in case the output contains substrings
+        # that would be interpreted as closing tags by the RichHandler
+        logger.log(
+            level=log_level,
+            msg=f"{log_prefix} {line}",
+            extra={"markup": False},
+        )
+
+
+def _drain_process(process: subprocess.Popen[str]) -> None:
+    """Read lines from the process's stdout and stderr and log them."""
+    assert process.stdout is not None
+    assert process.stderr is not None
+    _log_output(
+        process.stdout,
+        LogPrefix.RUN_STDOUT,
+    )
+    _log_output(
+        process.stderr,
+        LogPrefix.RUN_STDERR,
+        log_level=logging.ERROR,
+    )
+
+
+def _build_command(
+    command_or_args: Sequence[str] | str, quiet: bool = False
+) -> tuple[str, list[str]]:
+    """Build display and argument representations of a command."""
+    if isinstance(command_or_args, str):
+        command = command_or_args
+        args = shlex.split(command)
+    else:
+        args = [str(arg) for arg in command_or_args]
+        command = shlex.join(args)
+
+    if not quiet:
+        _log_command(command)
+
+    return command, args
+
+
+def _execute_process(
+    command_or_args: Sequence[str] | str,
+    /,
+    *,
+    command: str,
+    check: bool,
+    **kwargs: Any,
+) -> subprocess.Popen[str]:
+    """Execute a command and stream its output to the log."""
+    process: subprocess.Popen[str] = subprocess.Popen(
+        command_or_args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        **kwargs,
+    )
+
+    while process.poll() is None:
+        _drain_process(process)
+
+    # final drain: the poll() loop can exit before the last lines written
+    # just prior to process termination are read, so flush any remaining
+    # buffered output now that the process has exited.
+    _drain_process(process)
+
+    if check and process.returncode != 0:
+        raise subprocess.CalledProcessError(process.returncode, command)
+
+    return process
 
 
 class CommandRunner(Protocol):
@@ -50,7 +130,7 @@ def run_command(
     check: bool = True,
     quiet: bool = False,
     dry_run: bool = False,
-    **kwargs,
+    **kwargs: Any,
 ) -> subprocess.Popen[str] | str:
     """Run a command in a subprocess.
 
@@ -79,46 +159,7 @@ def run_command(
     -------
     subprocess.Popen or str
     """
-
-    def process_output(output_source, log_prefix: str, log_level=logging.INFO):
-        """Consume lines from an IO stream and log them."""
-        for line in output_source:
-            line = line.strip("\n")
-            # using extra={"markup": False} in case the output contains substrings
-            # that would be interpreted as closing tags by the RichHandler
-            logger.log(
-                level=log_level,
-                msg=f"{log_prefix} {line}",
-                extra={"markup": False},
-            )
-
-    def drain_process(process: subprocess.Popen[str]):
-        """Read lines from the process's stdout and stderr and log them."""
-        process_output(
-            process.stdout,
-            LogPrefix.RUN_STDOUT,
-        )
-        process_output(
-            process.stderr,
-            LogPrefix.RUN_STDERR,
-            log_level=logging.ERROR,
-        )
-
-    def build_cmd(command_or_args: Sequence[str] | str) -> tuple[str, list[str]]:
-        # build command string
-        if isinstance(command_or_args, str):
-            command = command_or_args
-            args = shlex.split(command)
-        else:
-            args = [str(arg) for arg in command_or_args]
-            command = shlex.join(args)
-
-        return command, args
-
-    command, args = build_cmd(command_or_args)
-
-    if not quiet:
-        _log_command(command)
+    command, args = _build_command(command_or_args, quiet=quiet)
 
     if dry_run:
         return command
@@ -127,23 +168,9 @@ def run_command(
     if not kwargs.get("shell"):
         command_or_args = args
 
-    process: subprocess.Popen[str] = subprocess.Popen(
+    return _execute_process(
         command_or_args,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
+        command=command,
+        check=check,
         **kwargs,
     )
-
-    while process.poll() is None:
-        drain_process(process)
-
-    # final drain: the poll() loop can exit before the last lines written
-    # just prior to process termination are read, so flush any remaining
-    # buffered output now that the process has exited.
-    drain_process(process)
-
-    if check and process.returncode != 0:
-        raise subprocess.CalledProcessError(process.returncode, command)
-
-    return process

--- a/nipoppy/utils/subprocess_runner.py
+++ b/nipoppy/utils/subprocess_runner.py
@@ -12,7 +12,7 @@ from nipoppy.logger import get_logger
 logger = get_logger()
 
 
-class LogPrefix:
+class _LogPrefix:
     """Prefixes for logging subprocess output."""
 
     RUN = "[RUN]"
@@ -24,7 +24,7 @@ def _log_command(command: str) -> None:
     """Write a command to the log with a special prefix."""
     # using extra={"markup": False} in case the command contains substrings
     # that would be interpreted as closing tags by the RichHandler
-    logger.info(f"{LogPrefix.RUN} {command}", extra={"markup": False})
+    logger.info(f"{_LogPrefix.RUN} {command}", extra={"markup": False})
 
 
 def _log_output(
@@ -50,11 +50,11 @@ def _drain_process(process: subprocess.Popen[str]) -> None:
     assert process.stderr is not None
     _log_output(
         process.stdout,
-        LogPrefix.RUN_STDOUT,
+        _LogPrefix.RUN_STDOUT,
     )
     _log_output(
         process.stderr,
-        LogPrefix.RUN_STDERR,
+        _LogPrefix.RUN_STDERR,
         log_level=logging.ERROR,
     )
 

--- a/nipoppy/workflows/base.py
+++ b/nipoppy/workflows/base.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-import logging
-import shlex
-import subprocess
 from abc import ABC, abstractmethod
 from functools import cached_property
 from pathlib import Path
-from typing import Optional, Protocol, Sequence
+from typing import Optional
 
 from nipoppy.base import Base
 from nipoppy.env import EXT_LOG, StrOrPathLike
@@ -28,131 +25,6 @@ from nipoppy.utils.utils import (
 )
 
 logger = get_logger()
-
-
-class LogPrefix:
-    """Prefixes for logging subprocess output."""
-
-    RUN = "[RUN]"
-    RUN_STDOUT = "[RUN STDOUT]"
-    RUN_STDERR = "[RUN STDERR]"
-
-
-def _log_command(command: str):
-    """Write a command to the log with a special prefix."""
-    # using extra={"markup": False} in case the command contains substrings
-    # that would be interpreted as closing tags by the RichHandler
-    logger.info(f"{LogPrefix.RUN} {command}", extra={"markup": False})
-
-
-class CommandRunner(Protocol):
-    """Protocol for functions that run commands, used for strategy injection."""
-
-    def __call__(
-        self,
-        command_or_args: Sequence[str] | str,
-        /,
-        *,
-        check: bool = True,
-        quiet: bool = False,
-        dry_run: bool = False,
-    ) -> subprocess.Popen[str] | str:
-        """Run a command in a subprocess, with logging and dry-run support."""
-        ...
-
-
-def _run_command(
-    command_or_args: Sequence[str] | str,
-    /,
-    *,
-    check: bool = True,
-    quiet: bool = False,
-    dry_run: bool = False,
-    **kwargs,
-) -> subprocess.Popen[str] | str:
-    """Run a command in a subprocess.
-
-    The command's stdout and stderr outputs are written to the log
-    with special prefixes.
-
-    If in "dry run" mode, the command is not executed, and the method returns
-    the command string. Otherwise, the subprocess.Popen object is returned
-    unless capture_output is True.
-
-    Parameters
-    ----------
-    command_or_args : Sequence[str]  |  str
-        The command to run.
-    check : bool, optional
-        If True, raise an error if the process exits with a non-zero code,
-        by default True
-    quiet : bool, optional
-        If True, do not log the command, by default False
-    **kwargs
-        Passed to `subprocess.Popen`.
-
-    Returns
-    -------
-    subprocess.Popen or str
-    """
-
-    def process_output(output_source, log_prefix: str, log_level=logging.INFO):
-        """Consume lines from an IO stream and log them."""
-        for line in output_source:
-            line = line.strip("\n")
-            # using extra={"markup": False} in case the output contains substrings
-            # that would be interpreted as closing tags by the RichHandler
-            logger.log(
-                level=log_level,
-                msg=f"{log_prefix} {line}",
-                extra={"markup": False},
-            )
-
-    # build command string
-    if not isinstance(command_or_args, str):
-        args = [str(arg) for arg in command_or_args]
-        command = shlex.join(args)
-    else:
-        command = command_or_args
-        args = shlex.split(command)
-
-    # only pass a single string if shell is True
-    if not kwargs.get("shell"):
-        command_or_args = args
-
-    if not quiet:
-        _log_command(command)
-
-    if not dry_run:
-        process: subprocess.Popen[str] = subprocess.Popen(
-            command_or_args,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            **kwargs,
-        )
-
-        while process.poll() is None:
-            process_output(
-                process.stdout,
-                LogPrefix.RUN_STDOUT,
-            )
-
-            process_output(
-                process.stderr,
-                LogPrefix.RUN_STDERR,
-                log_level=logging.ERROR,
-            )
-
-        if check and process.returncode != 0:
-            raise subprocess.CalledProcessError(process.returncode, command)
-
-        run_output = process
-
-    else:
-        run_output = command
-
-    return run_output
 
 
 class BaseWorkflow(Base, ABC):

--- a/nipoppy/workflows/base.py
+++ b/nipoppy/workflows/base.py
@@ -28,8 +28,10 @@ logger = get_logger()
 
 
 class BaseWorkflow(Base, ABC):
-    """Base workflow class with logging/subprocess/filesystem utilities."""
+    """Base workflow class with shared workflow and logging utilities.
 
+    For subprocess helpers, see :mod:`nipoppy.utils.subprocess_runner`.
+    """
     def __init__(self, name: str, verbose: bool = False, dry_run: bool = False):
         """Initialize the workflow instance.
 

--- a/nipoppy/workflows/pipeline_store/install.py
+++ b/nipoppy/workflows/pipeline_store/install.py
@@ -19,8 +19,9 @@ from nipoppy.exceptions import (
 from nipoppy.logger import get_logger
 from nipoppy.pipeline_validation import check_pipeline_bundle
 from nipoppy.utils import fileops
+from nipoppy.utils.subprocess_runner import run_command
 from nipoppy.utils.utils import apply_substitutions_to_json, process_template_str
-from nipoppy.workflows.base import BaseDatasetWorkflow, _run_command
+from nipoppy.workflows.base import BaseDatasetWorkflow
 from nipoppy.zenodo_api import ZenodoAPI
 
 logger = get_logger()
@@ -174,7 +175,7 @@ class PipelineInstallWorkflow(BaseDatasetWorkflow):
                 with console.status(
                     "Downloading the container, this can take a while..."
                 ):
-                    _run_command(pull_command, dry_run=self.dry_run)
+                    run_command(pull_command, dry_run=self.dry_run)
             except subprocess.CalledProcessError as e:
                 logger.error(
                     f"Failed to download container {pipeline_config.CONTAINER_INFO.URI}"

--- a/nipoppy/workflows/processing_runner.py
+++ b/nipoppy/workflows/processing_runner.py
@@ -2,15 +2,13 @@
 
 from functools import cached_property
 from pathlib import Path
-from tarfile import is_tarfile
 from typing import Optional
 
 from nipoppy.config.tracker import TrackerConfig
-from nipoppy.env import EXT_TAR, StrOrPathLike
+from nipoppy.env import StrOrPathLike
 from nipoppy.exceptions import ConfigError, FileOperationError
 from nipoppy.logger import get_logger
 from nipoppy.utils import fileops
-from nipoppy.workflows.base import _run_command
 from nipoppy.workflows.runner import Runner
 
 logger = get_logger()
@@ -88,31 +86,6 @@ class ProcessingRunner(Runner):
                 "in the tracker config file at "
                 f"{self.pipeline_step_config.TRACKER_CONFIG_FILE}"
             )
-
-    def tar_directory(self, dpath: StrOrPathLike) -> Path:
-        """Tar a directory and delete it."""
-        dpath = Path(dpath)
-        if not dpath.exists():
-            raise FileOperationError(f"Not tarring {dpath} since it does not exist")
-        if not dpath.is_dir():
-            raise FileOperationError(f"Not tarring {dpath} since it is not a directory")
-
-        tar_flags = "-cvf"
-        fpath_tarred = dpath.with_suffix(EXT_TAR)
-
-        _run_command(
-            f"tar {tar_flags} {fpath_tarred} -C {dpath.parent} {dpath.name}",
-            dry_run=self.dry_run,
-        )
-
-        # make sure that the tarfile was created successfully before removing
-        # original directory
-        if fpath_tarred.exists() and is_tarfile(fpath_tarred):
-            fileops.rm(dpath, dry_run=self.dry_run)
-        else:
-            logger.error(f"Failed to tar {dpath} to {fpath_tarred}")
-
-        return fpath_tarred
 
     def get_participants_sessions_to_run(
         self, participant_id: Optional[str], session_id: Optional[str]
@@ -214,9 +187,12 @@ class ProcessingRunner(Runner):
                     session_id=session_id,
                 )
             )
-            self.tar_directory(
+            dpath_to_tar = (
                 self.dpath_pipeline_output / tracker_config.PARTICIPANT_SESSION_DIR
             )
+            fpath_tarred = fileops.tar_directory(dpath_to_tar, dry_run=self.dry_run)
+            if fpath_tarred.exists():
+                fileops.rm(dpath_to_tar, dry_run=self.dry_run)
 
         return invocation_and_descriptor
 

--- a/nipoppy/workflows/runner.py
+++ b/nipoppy/workflows/runner.py
@@ -15,8 +15,8 @@ from nipoppy.config.container import ContainerConfig
 from nipoppy.container import ContainerHandler, get_container_handler
 from nipoppy.env import ContainerCommandEnum, StrOrPathLike
 from nipoppy.logger import get_logger
+from nipoppy.utils.subprocess_runner import run_command
 from nipoppy.utils.utils import TEMPLATE_REPLACE_PATTERN, get_pipeline_tag
-from nipoppy.workflows.base import _run_command
 from nipoppy.workflows.pipeline import BasePipelineWorkflow
 from nipoppy.workflows.services.boutiques import (
     BoshRunnerCallable,
@@ -202,7 +202,7 @@ class Runner(BasePipelineWorkflow, ABC):
             invocation_str=invocation_str,
             descriptor_str=descriptor_str,
             bosh_exec_launch_args=bosh_exec_launch_args,
-            run_command=_run_command,
+            run_command=run_command,
             dry_run=self.dry_run,
         )
 

--- a/nipoppy/workflows/services/boutiques.py
+++ b/nipoppy/workflows/services/boutiques.py
@@ -7,7 +7,7 @@ from typing import Protocol
 
 from nipoppy.exceptions import ExecutionError
 from nipoppy.logger import get_logger
-from nipoppy.workflows.base import CommandRunner
+from nipoppy.utils.subprocess_runner import CommandRunner
 
 logger = get_logger()
 

--- a/tests/unit/utils/test_fileops.py
+++ b/tests/unit/utils/test_fileops.py
@@ -263,17 +263,13 @@ class TestTarDirectory:
         self,
         dpath_to_tar: Path,
         mocker: pytest_mock.MockerFixture,
-        caplog: pytest.LogCaptureFixture,
     ):
-        """An error is logged when the tarball cannot be validated."""
+        """Raise a FileOperationError when the tarball cannot be validated."""
         # Mock is_tarfile to return False to simulate a failure in tarball creation
         mocker.patch("nipoppy.utils.fileops.is_tarfile", return_value=False)
 
-        fpath_tarred = fileops.tar_directory(dpath_to_tar)
-
-        assert fpath_tarred.exists()
-        assert dpath_to_tar.exists()
-        assert f"Failed to tar {dpath_to_tar}" in caplog.text
+        with pytest.raises(FileOperationError, match=f"Failed to tar {dpath_to_tar}"):
+            fileops.tar_directory(dpath_to_tar)
 
     @pytest.mark.parametrize(
         "make_path,match",
@@ -293,11 +289,12 @@ class TestTarDirectory:
     def test_tar_directory_dry_run(
         self, dpath_to_tar: Path, mocker: pytest_mock.MockerFixture
     ):
-        """No subprocess call and no tarball created in dry-run mode."""
-        mocked_run = mocker.patch("nipoppy.utils.fileops.subprocess.run")
+        """`run_command` is invoked with dry_run=True and no tarball is created."""
+        mocked_run = mocker.patch("nipoppy.utils.fileops.run_command")
 
         fpath_tarred = fileops.tar_directory(dpath_to_tar, dry_run=True)
 
-        mocked_run.assert_not_called()
+        mocked_run.assert_called_once()
+        assert mocked_run.call_args.kwargs.get("dry_run") is True
         assert fpath_tarred == dpath_to_tar.with_suffix(".tar")
         assert not fpath_tarred.exists()

--- a/tests/unit/utils/test_fileops.py
+++ b/tests/unit/utils/test_fileops.py
@@ -236,7 +236,8 @@ class TestSymlink:
 def dpath_to_tar(tmp_path: Path) -> Path:
     """Return a temporary directory with nested files, ready to be tarred."""
     dpath = tmp_path / "my_data"
-    (dpath / "dir1" / "file1.txt").mkdir(parents=True)
+    (dpath / "dir1").mkdir(parents=True)
+    (dpath / "dir1" / "file1.txt").touch()
     (dpath / "file2.txt").touch()
     return dpath
 

--- a/tests/unit/utils/test_fileops.py
+++ b/tests/unit/utils/test_fileops.py
@@ -1,4 +1,5 @@
 import errno
+import tarfile
 from contextlib import nullcontext
 from pathlib import Path
 
@@ -229,3 +230,73 @@ class TestSymlink:
 
         assert symlink.is_symlink()
         assert symlink.read_text() == expected_content
+
+
+@pytest.fixture
+def dpath_to_tar(tmp_path: Path) -> Path:
+    """Return a temporary directory with nested files, ready to be tarred."""
+    dpath = tmp_path / "my_data"
+    (dpath / "dir1" / "file1.txt").mkdir(parents=True)
+    (dpath / "file2.txt").touch()
+    return dpath
+
+
+class TestTarDirectory:
+    def test_tar_directory(self, dpath_to_tar: Path):
+        """Tarball is created with correct contents; source directory is left intact."""
+        fpath_tarred = fileops.tar_directory(dpath_to_tar)
+
+        assert fpath_tarred == dpath_to_tar.with_suffix(".tar")
+        assert fpath_tarred.is_file()
+
+        with tarfile.open(fpath_tarred) as tar:
+            assert set(tar.getnames()) == {
+                dpath_to_tar.name,
+                f"{dpath_to_tar.name}/file2.txt",
+                f"{dpath_to_tar.name}/dir1",
+                f"{dpath_to_tar.name}/dir1/file1.txt",
+            }
+
+    @pytest.mark.no_xdist
+    def test_tar_directory_failure(
+        self,
+        dpath_to_tar: Path,
+        mocker: pytest_mock.MockerFixture,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """An error is logged when the tarball cannot be validated."""
+        # Mock is_tarfile to return False to simulate a failure in tarball creation
+        mocker.patch("nipoppy.utils.fileops.is_tarfile", return_value=False)
+
+        fpath_tarred = fileops.tar_directory(dpath_to_tar)
+
+        assert fpath_tarred.exists()
+        assert dpath_to_tar.exists()
+        assert f"Failed to tar {dpath_to_tar}" in caplog.text
+
+    @pytest.mark.parametrize(
+        "make_path,match",
+        [
+            (lambda p: p / "nonexistent", "Dir does not exist:"),
+            (
+                lambda p: (p / "file.txt").touch() or p / "file.txt",
+                "Cannot tar non-directory:",
+            ),
+        ],
+    )
+    def test_tar_directory_invalid_input(self, tmp_path: Path, make_path, match):
+        """Ensure FileOperationError is raised for invalid paths."""
+        with pytest.raises(FileOperationError, match=match):
+            fileops.tar_directory(make_path(tmp_path))
+
+    def test_tar_directory_dry_run(
+        self, dpath_to_tar: Path, mocker: pytest_mock.MockerFixture
+    ):
+        """No subprocess call and no tarball created in dry-run mode."""
+        mocked_run = mocker.patch("nipoppy.utils.fileops.subprocess.run")
+
+        fpath_tarred = fileops.tar_directory(dpath_to_tar, dry_run=True)
+
+        mocked_run.assert_not_called()
+        assert fpath_tarred == dpath_to_tar.with_suffix(".tar")
+        assert not fpath_tarred.exists()

--- a/tests/unit/utils/test_fileops.py
+++ b/tests/unit/utils/test_fileops.py
@@ -234,7 +234,7 @@ class TestSymlink:
 
 @pytest.fixture
 def dpath_to_tar(tmp_path: Path) -> Path:
-    """Return a temporary directory with nested files, ready to be tarred."""
+    """Return a temporary directory with nested files."""
     dpath = tmp_path / "my_data"
     (dpath / "dir1").mkdir(parents=True)
     (dpath / "dir1" / "file1.txt").touch()

--- a/tests/unit/utils/test_subprocess_runner.py
+++ b/tests/unit/utils/test_subprocess_runner.py
@@ -1,0 +1,122 @@
+"""Tests for the subprocess runner utilities."""
+
+import logging
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from nipoppy.utils.subprocess_runner import (
+    LogPrefix,
+    _log_command,
+    run_command,
+)
+
+pytestmark = pytest.mark.no_xdist
+
+
+@pytest.mark.parametrize("command", ["echo x", "echo y"])
+def test_log_command(command, caplog: pytest.LogCaptureFixture):
+    _log_command(command)
+    assert caplog.records
+    record = caplog.records[-1]
+    assert record.levelno == logging.INFO
+    assert record.message.startswith(LogPrefix.RUN)
+    assert command in record.message
+
+
+def test_log_command_no_markup(caplog: pytest.LogCaptureFixture):
+    # message with closing tag
+    message = "[/]"
+
+    # this should not raise a rich markup error
+    run_command(["echo", message])
+    assert message in caplog.text
+
+
+def test_run_command(tmp_path: Path):
+    fpath = tmp_path / "test.txt"
+    process = run_command(["touch", str(fpath)])
+    assert isinstance(process, subprocess.Popen)
+    assert process.returncode == 0
+    assert fpath.exists()
+
+
+def test_run_command_single_string(tmp_path: Path):
+    fpath = tmp_path / "test.txt"
+    process = run_command(f"touch {fpath}", shell=True)
+    assert isinstance(process, subprocess.Popen)
+    assert process.returncode == 0
+    assert fpath.exists()
+
+
+def test_run_command_dry_run(tmp_path: Path):
+    fpath = tmp_path / "test.txt"
+    command = run_command(["touch", str(fpath)], dry_run=True)
+    assert isinstance(command, str)
+    assert command == f"touch {fpath}"
+    assert not fpath.exists()
+
+
+def test_run_command_check():
+    with pytest.raises(subprocess.CalledProcessError):
+        run_command(["which", "probably_fake_command"], check=True)
+
+
+def test_run_command_no_markup(caplog: pytest.LogCaptureFixture, tmp_path: Path):
+    # text with closing tag
+    text = "[/]"
+
+    # this should not raise a rich markup error
+    fpath_txt = tmp_path / "test.txt"
+    fpath_txt.write_text(text)
+    run_command(["cat", str(fpath_txt)])
+    assert text in caplog.text
+
+
+def test_run_command_quiet(caplog: pytest.LogCaptureFixture):
+    message = "This should be printed"
+    run_command(["echo", message], quiet=True)
+    assert LogPrefix.RUN not in caplog.text
+    assert message in caplog.text
+
+
+def test_run_command_streams_final_lines(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+):
+    """The final drain ensures the last buffered lines are logged.
+
+    Previously the `while process.poll() is None:` loop could exit before
+    reading lines written just prior to process termination; this test
+    guards against regressions of that fix.
+    """
+    final_stdout_line = "final-stdout-line"
+    final_stderr_line = "final-stderr-line"
+
+    # Force the race deterministically: make the first poll() call wait for
+    # the subprocess to exit. That way, the `while process.poll() is None`
+    # loop in run_command never enters its body, so only the post-loop
+    # "final drain" can capture the output.
+    original_poll = subprocess.Popen.poll
+
+    def wait_then_poll(self, *args, **kwargs):
+        if not getattr(self, "_first_poll_done", False):
+            self._first_poll_done = True
+            self.wait()
+        return original_poll(self, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess.Popen, "poll", wait_then_poll)
+
+    caplog.set_level(logging.DEBUG)
+
+    run_command(
+        [
+            "sh",
+            "-c",
+            f"echo {final_stdout_line}; echo {final_stderr_line} >&2",
+        ],
+        quiet=True,  # suppress the [RUN] line so assertions only match process output
+    )
+
+    assert f"{LogPrefix.RUN_STDOUT} {final_stdout_line}" in caplog.text
+    assert f"{LogPrefix.RUN_STDERR} {final_stderr_line}" in caplog.text

--- a/tests/unit/utils/test_subprocess_runner.py
+++ b/tests/unit/utils/test_subprocess_runner.py
@@ -7,8 +7,8 @@ from pathlib import Path
 import pytest
 
 from nipoppy.utils.subprocess_runner import (
-    LogPrefix,
     _log_command,
+    _LogPrefix,
     run_command,
 )
 
@@ -21,7 +21,7 @@ def test_log_command(command, caplog: pytest.LogCaptureFixture):
     assert caplog.records
     record = caplog.records[-1]
     assert record.levelno == logging.INFO
-    assert record.message.startswith(LogPrefix.RUN)
+    assert record.message.startswith(_LogPrefix.RUN)
     assert command in record.message
 
 
@@ -77,7 +77,7 @@ def test_run_command_no_markup(caplog: pytest.LogCaptureFixture, tmp_path: Path)
 def test_run_command_quiet(caplog: pytest.LogCaptureFixture):
     message = "This should be printed"
     run_command(["echo", message], quiet=True)
-    assert LogPrefix.RUN not in caplog.text
+    assert _LogPrefix.RUN not in caplog.text
     assert message in caplog.text
 
 
@@ -118,5 +118,5 @@ def test_run_command_streams_final_lines(
         quiet=True,  # suppress the [RUN] line so assertions only match process output
     )
 
-    assert f"{LogPrefix.RUN_STDOUT} {final_stdout_line}" in caplog.text
-    assert f"{LogPrefix.RUN_STDERR} {final_stderr_line}" in caplog.text
+    assert f"{_LogPrefix.RUN_STDOUT} {final_stdout_line}" in caplog.text
+    assert f"{_LogPrefix.RUN_STDERR} {final_stderr_line}" in caplog.text

--- a/tests/unit/workflows/pipeline_store/test_install.py
+++ b/tests/unit/workflows/pipeline_store/test_install.py
@@ -68,7 +68,7 @@ def workflow(
     )
 
     # mock singularity/apptainer pull (this is overridden by some tests)
-    mocker.patch("nipoppy.workflows.pipeline_store.install._run_command")
+    mocker.patch("nipoppy.workflows.pipeline_store.install.run_command")
 
     return workflow
 
@@ -241,7 +241,7 @@ def test_download_container(
         return_value=ApptainerHandler(),
     )
     mocked_run_command = mocker.patch(
-        "nipoppy.workflows.pipeline_store.install._run_command"
+        "nipoppy.workflows.pipeline_store.install.run_command"
     )
 
     workflow._download_container(pipeline_config)
@@ -285,7 +285,7 @@ def test_download_container_confirm_true(
     )
 
     mocked_run_command = mocker.patch(
-        "nipoppy.workflows.pipeline_store.install._run_command"
+        "nipoppy.workflows.pipeline_store.install.run_command"
     )
 
     workflow._download_container(pipeline_config)
@@ -318,7 +318,7 @@ def test_download_container_status(
         f"nipoppy.workflows.pipeline_store.install.{console}.status",
     )
     mocked_run_command = mocker.patch(
-        "nipoppy.workflows.pipeline_store.install._run_command"
+        "nipoppy.workflows.pipeline_store.install.run_command"
     )
 
     workflow.study.config.CONTAINER_CONFIG.COMMAND = command
@@ -339,7 +339,7 @@ def test_download_container_failed(
 ):
     error_message = "Download failed"
     mocked = mocker.patch(
-        "nipoppy.workflows.pipeline_store.install._run_command",
+        "nipoppy.workflows.pipeline_store.install.run_command",
         side_effect=subprocess.CalledProcessError(1, error_message),
     )
 
@@ -360,7 +360,7 @@ def test_download_container_no_uri(
     mocker: pytest_mock.MockFixture,
 ):
     pipeline_config.CONTAINER_INFO.URI = None
-    mocked = mocker.patch("nipoppy.workflows.pipeline_store.install._run_command")
+    mocked = mocker.patch("nipoppy.workflows.pipeline_store.install.run_command")
 
     workflow._download_container(pipeline_config)
 
@@ -378,7 +378,7 @@ def test_download_container_image_exists(
     )
     fpath_container.parent.mkdir(parents=True, exist_ok=True)
     fpath_container.touch()
-    mocked = mocker.patch("nipoppy.workflows.pipeline_store.install._run_command")
+    mocked = mocker.patch("nipoppy.workflows.pipeline_store.install.run_command")
 
     workflow._download_container(pipeline_config)
     mocked.assert_not_called()

--- a/tests/unit/workflows/services/test_boutiques.py
+++ b/tests/unit/workflows/services/test_boutiques.py
@@ -80,7 +80,7 @@ def test_run_bosh_func_capture_error(
 ):
     """Test that a Boutiques launch command captures errors correctly."""
     mocked_run_command = mocker.patch(
-        "nipoppy.workflows.base._run_command",
+        "nipoppy.utils.subprocess_runner.run_command",
         side_effect=subprocess.CalledProcessError(
             returncode=1,
             cmd=["bosh", "exec", "launch"],
@@ -104,7 +104,7 @@ def test_bosh_simulate_log(
     mocker: pytest_mock.MockerFixture,
 ):
     """Test that a Boutiques simulate command logs the command."""
-    mocked_run_command = mocker.patch("nipoppy.workflows.base._run_command")
+    mocked_run_command = mocker.patch("nipoppy.utils.subprocess_runner.run_command")
     run_bosh_simulate(
         invocation_str=json.dumps(invocation),
         descriptor_str=json.dumps(bosh_descriptor),

--- a/tests/unit/workflows/test_base.py
+++ b/tests/unit/workflows/test_base.py
@@ -1,12 +1,8 @@
 """Tests for the BaseWorkflow class."""
 
-import logging
-import subprocess
-from pathlib import Path
-
 import pytest
 
-from nipoppy.workflows.base import BaseWorkflow, LogPrefix, _log_command, _run_command
+from nipoppy.workflows.base import BaseWorkflow
 
 
 @pytest.fixture()
@@ -30,75 +26,5 @@ def test_init(workflow: BaseWorkflow):
     assert workflow.return_code == 0
 
 
-@pytest.mark.parametrize("command", ["echo x", "echo y"])
-@pytest.mark.no_xdist
-def test_log_command(command, caplog: pytest.LogCaptureFixture):
-    _log_command(command)
-    assert caplog.records
-    record = caplog.records[-1]
-    assert record.levelno == logging.INFO
-    assert record.message.startswith(LogPrefix.RUN)
-    assert command in record.message
-
-
 def test_run(workflow: BaseWorkflow):
     assert workflow.run() is None
-
-
-# TODO we might want to move these tests to a separate test file or reorganize them
-# Previously, were using the BaseWorkflow.run_command method, which has been extracted
-# to a standalone function. The tests have been adapted accordingly.
-@pytest.mark.no_xdist
-def test_log_command_no_markup(caplog: pytest.LogCaptureFixture):
-    # message with closing tag
-    message = "[/]"
-
-    # this should not raise a rich markup error
-    _run_command(["echo", message])
-    assert message in caplog.text
-
-
-def test_run_command(tmp_path: Path):
-    fpath = tmp_path / "test.txt"
-    process = _run_command(["touch", fpath])
-    assert process.returncode == 0
-    assert fpath.exists()
-
-
-def test_run_command_single_string(tmp_path: Path):
-    fpath = tmp_path / "test.txt"
-    process = _run_command(f"touch {fpath}", shell=True)
-    assert process.returncode == 0
-    assert fpath.exists()
-
-
-def test_run_command_dry_run(tmp_path: Path):
-    fpath = tmp_path / "test.txt"
-    command = _run_command(["touch", fpath], dry_run=True)
-    assert command == f"touch {fpath}"
-    assert not fpath.exists()
-
-
-def test_run_command_check():
-    with pytest.raises(subprocess.CalledProcessError):
-        _run_command(["which", "probably_fake_command"], check=True)
-
-
-@pytest.mark.no_xdist
-def test_run_command_no_markup(caplog: pytest.LogCaptureFixture, tmp_path: Path):
-    # text with closing tag
-    text = "[/]"
-
-    # this should not raise a rich markup error
-    fpath_txt = tmp_path / "test.txt"
-    fpath_txt.write_text(text)
-    _run_command(["cat", fpath_txt])
-    assert text in caplog.text
-
-
-@pytest.mark.no_xdist
-def test_run_command_quiet(caplog: pytest.LogCaptureFixture):
-    message = "This should be printed"
-    _run_command(["echo", message], quiet=True)
-    assert LogPrefix.RUN not in caplog.text
-    assert message in caplog.text

--- a/tests/unit/workflows/test_processing_runner.py
+++ b/tests/unit/workflows/test_processing_runner.py
@@ -1,7 +1,6 @@
 """Tests for PipelineRunner."""
 
 import json
-import tarfile
 from pathlib import Path
 
 import pytest
@@ -365,79 +364,6 @@ def test_check_tar_conditions_no_tar(runner: ProcessingRunner):
     runner._check_tar_conditions()
 
 
-@pytest.mark.parametrize("dpath_type", [Path, str])
-def test_tar_directory(tmp_path: Path, dpath_type):
-    # create dummy files to tar
-    dpath_to_tar = tmp_path / "my_data"
-    fpaths_to_tar = [
-        dpath_to_tar / "dir1" / "file1.txt",
-        dpath_to_tar / "file2.txt",
-    ]
-    for fpath in fpaths_to_tar:
-        fpath.parent.mkdir(parents=True, exist_ok=True)
-        fpath.touch()
-
-    runner = ProcessingRunner(
-        dpath_root=tmp_path / "my_dataset",
-        pipeline_name="dummy_pipeline",
-        pipeline_version="1.0.0",
-    )
-    fpath_tarred = runner.tar_directory(dpath_type(dpath_to_tar))
-
-    assert fpath_tarred == dpath_to_tar.with_suffix(".tar")
-    assert fpath_tarred.exists()
-    assert fpath_tarred.is_file()
-
-    with tarfile.open(fpath_tarred, "r") as tar:
-        tarred_files = {
-            tmp_path / tarred.name for tarred in tar.getmembers() if tarred.isfile()
-        }
-    assert tarred_files == set(fpaths_to_tar)
-
-    assert not dpath_to_tar.exists()
-
-
-@pytest.mark.no_xdist
-def test_tar_directory_failure(
-    runner: ProcessingRunner,
-    tmp_path: Path,
-    mocker: pytest_mock.MockFixture,
-    caplog: pytest.LogCaptureFixture,
-):
-    dpath_to_tar = tmp_path / "my_data"
-    fpath_to_tar = dpath_to_tar / "file.txt"
-    fpath_to_tar.parent.mkdir(parents=True)
-    fpath_to_tar.touch()
-
-    mocked_is_tarfile = mocker.patch(
-        "nipoppy.workflows.processing_runner.is_tarfile", return_value=False
-    )
-
-    fpath_tarred = runner.tar_directory(dpath_to_tar)
-
-    assert fpath_tarred.exists()
-    mocked_is_tarfile.assert_called_once()
-
-    assert f"Failed to tar {dpath_to_tar}" in caplog.text
-
-
-def test_tar_directory_warning_not_found(runner: ProcessingRunner):
-    with pytest.raises(
-        FileOperationError, match="Not tarring .* since it does not exist"
-    ):
-        runner.tar_directory("invalid_path")
-
-
-def test_tar_directory_warning_not_dir(runner: ProcessingRunner, tmp_path: Path):
-    fpath_to_tar = tmp_path / "file.txt"
-    fpath_to_tar.touch()
-
-    with pytest.raises(
-        FileOperationError, match="Not tarring .* since it is not a directory"
-    ):
-        runner.tar_directory(fpath_to_tar)
-
-
 @pytest.mark.parametrize(
     "curation_status_data,processing_status_data,pipeline_step,expected",
     [
@@ -723,8 +649,11 @@ def test_run_single_tar(
         side_effect=None if boutiques_success else RuntimeError(exception_message),
     )
 
-    # mock tar_directory method (will check if/how this is called)
-    mocked_tar_directory = mocker.patch.object(runner, "tar_directory")
+    # mock tar_directory and rm functions (will check if/how tar_directory is called)
+    mocked_tar_directory = mocker.patch(
+        "nipoppy.workflows.processing_runner.fileops.tar_directory"
+    )
+    mocker.patch("nipoppy.workflows.processing_runner.fileops.rm")
 
     participant_id = "01"
     session_id = "1"
@@ -742,7 +671,8 @@ def test_run_single_tar(
 
     if tar and boutiques_success:
         mocked_tar_directory.assert_called_once_with(
-            runner.dpath_pipeline_output / f"{participant_id}_ses-{session_id}"
+            runner.dpath_pipeline_output / f"{participant_id}_ses-{session_id}",
+            dry_run=runner.dry_run,
         )
     else:
         mocked_tar_directory.assert_not_called()

--- a/tests/unit/workflows/test_processing_runner.py
+++ b/tests/unit/workflows/test_processing_runner.py
@@ -173,7 +173,7 @@ def test_launch_boutiques_run(
     participant_id = "01"
     session_id = "BL"
 
-    mocked_run_command = mocker.patch("nipoppy.workflows.runner._run_command")
+    mocked_run_command = mocker.patch("nipoppy.workflows.runner.run_command")
 
     descriptor_str, invocation_str = runner.launch_boutiques_run(
         participant_id, session_id
@@ -238,7 +238,7 @@ def test_launch_boutiques_run_bosh_opts(
     participant_id = "01"
     session_id = "BL"
 
-    mocked_run_command = mocker.patch("nipoppy.workflows.runner._run_command")
+    mocked_run_command = mocker.patch("nipoppy.workflows.runner.run_command")
 
     runner.launch_boutiques_run(
         participant_id,
@@ -272,7 +272,7 @@ def test_launch_boutiques_run_bosh_no_container_image(
     participant_id = "01"
     session_id = "BL"
 
-    mocked_run_command = mocker.patch("nipoppy.workflows.runner._run_command")
+    mocked_run_command = mocker.patch("nipoppy.workflows.runner.run_command")
 
     runner.launch_boutiques_run(
         participant_id,

--- a/tests/unit/workflows/test_tracker.py
+++ b/tests/unit/workflows/test_tracker.py
@@ -12,7 +12,7 @@ from nipoppy.env import DEFAULT_PIPELINE_STEP_NAME
 from nipoppy.tabular.curation_status import CurationStatusTable
 from nipoppy.tabular.manifest import Manifest
 from nipoppy.tabular.processing_status import ProcessingStatusTable
-from nipoppy.workflows.processing_runner import ProcessingRunner
+from nipoppy.utils import fileops
 from nipoppy.workflows.tracker import PipelineTracker
 from tests.conftest import (
     create_empty_dataset,
@@ -200,13 +200,9 @@ def test_check_status_with_tarball(
         fpath.parent.mkdir(parents=True, exist_ok=True)
         fpath.touch()
 
-    # use PipelineRunner to tar the directory
     dpath_to_tar = tracker.dpath_pipeline_output / relative_dpath_to_tar
-    ProcessingRunner(
-        tracker.dpath_root, tracker.pipeline_name, tracker.pipeline_version
-    ).tar_directory(dpath_to_tar)
+    fileops.tar_directory(dpath_to_tar)
 
-    assert not dpath_to_tar.exists()
     assert (
         tracker.check_status(relative_paths, relative_dpath_to_tar) == expected_status
     )
@@ -290,11 +286,8 @@ def test_run_single(
 
     for relative_dpath_to_tar in ["01/ses-1", "02/ses-1"]:
         dpath_to_tar = tracker.dpath_pipeline_output / relative_dpath_to_tar
-        ProcessingRunner(
-            tracker.dpath_root, tracker.pipeline_name, tracker.pipeline_version
-        ).tar_directory(dpath_to_tar)
+        fileops.tar_directory(dpath_to_tar)
 
-    assert not dpath_to_tar.exists()
     assert (
         tracker.run_single(participant_id, session_id)[ProcessingStatusTable.col_status]
         == expected_status

--- a/tests/unit/workflows/test_tracker.py
+++ b/tests/unit/workflows/test_tracker.py
@@ -202,7 +202,9 @@ def test_check_status_with_tarball(
 
     dpath_to_tar = tracker.dpath_pipeline_output / relative_dpath_to_tar
     fileops.tar_directory(dpath_to_tar)
+    fileops.rm(dpath_to_tar)
 
+    assert not dpath_to_tar.exists(), "Tarball should have been removed for the test"
     assert (
         tracker.check_status(relative_paths, relative_dpath_to_tar) == expected_status
     )
@@ -287,6 +289,10 @@ def test_run_single(
     for relative_dpath_to_tar in ["01/ses-1", "02/ses-1"]:
         dpath_to_tar = tracker.dpath_pipeline_output / relative_dpath_to_tar
         fileops.tar_directory(dpath_to_tar)
+        fileops.rm(dpath_to_tar)
+        assert (
+            not dpath_to_tar.exists()
+        ), "Tarball should have been removed for the test"
 
     assert (
         tracker.run_single(participant_id, session_id)[ProcessingStatusTable.col_status]


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #888 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
Move the`tar_directory` function from the ProcessingRunner to the fileops module.

Also moved the `run_command` function from the base workflow module to a dedicated new module. Otherwise, there were issue with circular dependency.

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--991.org.readthedocs.build/en/991/

<!-- readthedocs-preview nipoppy end -->