### PR TITLE
[MAINT] Remove AI specfic section in favor of `.git/info/exclude`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,11 +50,3 @@ nipoppy_env/
 
 # all-contributors CLI
 node_modules
-
-# Agentic workflows
-speckit*.md
-.specify
-specs/
-.squad
-.github/workflows/*squad-*.yml
-.copilot


### PR DESCRIPTION
Given the speed at which new framework are coming out, there's a risk that we clutter
the `.gitignore`.

<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--1004.org.readthedocs.build/en/1004/

<!-- readthedocs-preview nipoppy end -->