### PR TITLE
[MAINT] Start deprecation cycle for descriptors with Nipoppy-specific template strings

### DIFF
--- a/nipoppy/pipeline_validation.py
+++ b/nipoppy/pipeline_validation.py
@@ -63,7 +63,9 @@ def _load_pipeline_config_file(fpath_config: Path) -> BasePipelineConfig:
     return config
 
 
-def _check_descriptor_file(fpath_descriptor: StrOrPathLike) -> None:
+def _check_descriptor_file(
+    fpath_descriptor: StrOrPathLike, strict: bool = False
+) -> None:
     """Validate a Boutiques descriptor file."""
     fpath_descriptor: Path = Path(fpath_descriptor)
     if not fpath_descriptor.exists():
@@ -83,11 +85,18 @@ def _check_descriptor_file(fpath_descriptor: StrOrPathLike) -> None:
         )
 
     if TEMPLATE_REPLACE_PATTERN.search(descriptor_str) is not None:
-        logger.warning(
-            f"Descriptor file {fpath_descriptor} contains Nipoppy-specific template "
-            "variables. Consider updating this file as this will no longer be "
-            "supported in future versions."
-        )
+        error_message = f"Descriptor file {fpath_descriptor} contains Nipoppy-specific template variables. "  # noqa E501
+        if strict:
+            raise ConfigError(
+                error_message
+                + 'Please remove these variables, add a "container-image" field, and update "command-line" to include the pipeline executable. '  # noqa E501
+                + "See example here: https://zenodo.org/records/16876772?preview_file=descriptor.json."  # noqa E501
+            )
+        else:
+            logger.warning(
+                error_message
+                + "Consider updating this file as it will no longer be supported in a future version of Nipoppy."  # noqa E501
+            )
 
     return descriptor_str
 

--- a/nipoppy/pipeline_validation.py
+++ b/nipoppy/pipeline_validation.py
@@ -182,6 +182,7 @@ def _check_pipeline_files(
     pipeline_config: BasePipelineConfig,
     dpath_bundle: StrOrPathLike,
     *,
+    strict: bool = False,
     log_level: int = logging.DEBUG,
 ) -> list[Path]:
     """
@@ -194,6 +195,8 @@ def _check_pipeline_files(
     - the HPC config file (if present)
     - the tracker config file (if present and pipeline is a processing pipeline)
     - the PyBIDS ignore patterns file (if present and pipeline is a processing pipeline)
+
+    If strict is True, raise error instead of warning in descriptor check.
 
     Also, collect all file paths for these files for further checks.
     """
@@ -211,7 +214,7 @@ def _check_pipeline_files(
                 msg=f"\tChecking descriptor file: {step.DESCRIPTOR_FILE}",
             )
             fpath_descriptor = dpath_bundle / step.DESCRIPTOR_FILE
-            descriptor_str = _check_descriptor_file(fpath_descriptor)
+            descriptor_str = _check_descriptor_file(fpath_descriptor, strict=strict)
             fpaths.append(fpath_descriptor)
 
             if step.INVOCATION_FILE is not None:
@@ -284,9 +287,13 @@ def _check_no_subdirectories(dpath_bundle: StrOrPathLike):
 
 
 def check_pipeline_bundle(
-    dpath_bundle: StrOrPathLike, log_level: int = logging.DEBUG
+    dpath_bundle: StrOrPathLike, log_level: int = logging.DEBUG, strict: bool = False
 ) -> BasePipelineConfig:
-    """Load a pipeline bundle's main configuration file and validate it."""
+    """
+    Load a pipeline bundle's main configuration file and validate it.
+
+    If strict is True, raise error instead of warning in descriptor check.
+    """
     dpath_bundle = Path(dpath_bundle).resolve()
     fpath_config: Path = dpath_bundle / DatasetLayout.fname_pipeline_config
 
@@ -294,7 +301,9 @@ def check_pipeline_bundle(
     config = _load_pipeline_config_file(fpath_config)
 
     # core file content validation
-    fpaths = _check_pipeline_files(config, dpath_bundle, log_level=log_level)
+    fpaths = _check_pipeline_files(
+        config, dpath_bundle, log_level=log_level, strict=strict
+    )
 
     # make sure that all files are within the bundle directory
     _check_self_contained(dpath_bundle, fpaths)

--- a/nipoppy/pipeline_validation.py
+++ b/nipoppy/pipeline_validation.py
@@ -65,7 +65,7 @@ def _load_pipeline_config_file(fpath_config: Path) -> BasePipelineConfig:
 
 def _check_descriptor_file(
     fpath_descriptor: StrOrPathLike, strict: bool = False
-) -> None:
+) -> str:
     """Validate a Boutiques descriptor file."""
     fpath_descriptor: Path = Path(fpath_descriptor)
     if not fpath_descriptor.exists():

--- a/nipoppy/pipeline_validation.py
+++ b/nipoppy/pipeline_validation.py
@@ -20,7 +20,7 @@ from nipoppy.env import PipelineTypeEnum, StrOrPathLike
 from nipoppy.exceptions import ConfigError, FileOperationError
 from nipoppy.layout import DatasetLayout, LayoutError
 from nipoppy.logger import get_logger
-from nipoppy.utils.utils import load_json
+from nipoppy.utils.utils import TEMPLATE_REPLACE_PATTERN, load_json
 
 logger = get_logger()
 
@@ -81,6 +81,14 @@ def _check_descriptor_file(fpath_descriptor: StrOrPathLike) -> None:
         raise ConfigError(
             f"Descriptor file {fpath_descriptor} is invalid:\n{exception}"
         )
+
+    if TEMPLATE_REPLACE_PATTERN.search(descriptor_str) is not None:
+        logger.warning(
+            f"Descriptor file {fpath_descriptor} contains Nipoppy-specific template "
+            "variables. Consider updating this file as this will no longer be "
+            "supported in future versions."
+        )
+
     return descriptor_str
 
 

--- a/nipoppy/pipeline_validation.py
+++ b/nipoppy/pipeline_validation.py
@@ -95,7 +95,7 @@ def _check_descriptor_file(
         else:
             logger.warning(
                 error_message
-                + "Consider updating this file as it will no longer be supported in a future version of Nipoppy."  # noqa E501
+                + "You should update this file as it will no longer be supported in a future version of Nipoppy."  # noqa E501
             )
 
     return descriptor_str

--- a/nipoppy/pipeline_validation.py
+++ b/nipoppy/pipeline_validation.py
@@ -95,7 +95,7 @@ def _check_descriptor_file(
         else:
             logger.warning(
                 error_message
-                + "You should update this file as it will no longer be supported in a future version of Nipoppy."  # noqa E501
+                + "This will be deprecated in the future: you should update this file following steps listed in https://nipoppy.readthedocs.io/en/0.4.1/changelog.html#release-0-4-1."  # noqa E501
             )
 
     return descriptor_str

--- a/nipoppy/workflows/pipeline_store/upload.py
+++ b/nipoppy/workflows/pipeline_store/upload.py
@@ -89,7 +89,7 @@ class PipelineUploadWorkflow(BaseWorkflow):
 
         # Safeguard before uploading
         try:
-            pipeline_config = check_pipeline_bundle(pipeline_dir)
+            pipeline_config = check_pipeline_bundle(pipeline_dir, strict=True)
         except Exception as e:
             logger.error(
                 f"Pipeline validation failed. Please check the pipeline files: {e}"

--- a/nipoppy/workflows/pipeline_store/validate.py
+++ b/nipoppy/workflows/pipeline_store/validate.py
@@ -30,6 +30,6 @@ class PipelineValidateWorkflow(BaseWorkflow):
     def run_main(self):
         """Run the main workflow."""
         logger.info(f"Validating pipeline at {self.dpath_pipeline}")
-        check_pipeline_bundle(self.dpath_pipeline, log_level=logging.INFO)
+        check_pipeline_bundle(self.dpath_pipeline, log_level=logging.INFO, strict=True)
 
         logger.success("The pipeline files are all valid")

--- a/tests/data/descriptor-deprecated.json
+++ b/tests/data/descriptor-deprecated.json
@@ -1,0 +1,81 @@
+{
+    "name": "tool name",
+    "description": "tool description",
+    "tool-version": "v0.1.0",
+    "schema-version": "0.5",
+    "command-line": "[[NIPOPPY_CONTAINER_COMMAND]] [[NIPOPPY_FPATH_CONTAINER]] echo [PARAM1] [PARAM2] [FLAG1] > [OUTPUT1]",
+    "container-image": {
+        "image": "user/image",
+        "index": "docker://",
+        "type": "singularity"
+    },
+    "inputs": [
+        {
+            "name": "The first parameter",
+            "id": "basic_param1",
+            "type": "File",
+            "optional": true,
+            "value-key": "[PARAM1]"
+        },
+        {
+            "name": "The second parameter",
+            "id": "basic_param2",
+            "type": "String",
+            "optional": false,
+            "value-key": "[PARAM2]",
+            "value-choices": [
+                "mychoice1.log",
+                "mychoice2.log"
+            ]
+        },
+        {
+            "name": "The first flag",
+            "id": "basic_flag1",
+            "type": "Flag",
+            "optional": true,
+            "command-line-flag": "-f",
+            "value-key": "[FLAG1]"
+        }
+    ],
+    "output-files": [
+        {
+            "name": "The first output",
+            "id": "basic_output1",
+            "optional": false,
+            "path-template": "[PARAM2].txt",
+            "path-template-stripped-extensions": [
+                ".log"
+            ],
+            "value-key": "[OUTPUT1]"
+        }
+    ],
+    "groups": [
+        {
+            "all-or-none": true,
+            "mutually-exclusive": false,
+            "one-is-required": false,
+            "name": "the param group",
+            "id": "group1",
+            "members": [
+                "basic_param1",
+                "basic_flag1"
+            ]
+        }
+    ],
+    "tags": {
+        "status": "example",
+        "purpose": "testing",
+        "foo": "bar"
+    },
+    "suggested-resources": {
+        "cpu-cores": 1,
+        "ram": 1,
+        "walltime-estimate": 60
+    },
+    "error-codes": [
+        {
+            "code": 1,
+            "description": "Crashed"
+        }
+    ]
+}

--- a/tests/unit/test_pipeline_validation.py
+++ b/tests/unit/test_pipeline_validation.py
@@ -91,7 +91,7 @@ def test_check_descriptor_file(caplog: pytest.LogCaptureFixture):
     assert len(caplog.records) == 0
 
 
-def test_check_descriptor_file_warning(caplog: pytest.LogCaptureFixture):
+def test_check_descriptor_file_deprecation_warning(caplog: pytest.LogCaptureFixture):
 
     _check_descriptor_file(DPATH_TEST_DATA / "descriptor-deprecated.json")
 
@@ -102,6 +102,17 @@ def test_check_descriptor_file_warning(caplog: pytest.LogCaptureFixture):
             for record in caplog.records
         ]
     )
+
+
+def test_check_descriptor_file_deprecation_error():
+
+    with pytest.raises(
+        ConfigError,
+        match="Descriptor file .* contains Nipoppy-specific template variables",
+    ):
+        _check_descriptor_file(
+            DPATH_TEST_DATA / "descriptor-deprecated.json", strict=True
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_pipeline_validation.py
+++ b/tests/unit/test_pipeline_validation.py
@@ -234,9 +234,9 @@ def test_check_pybids_ignore_file_invalid(fpath, exception_class, exception_mess
 
 
 @pytest.mark.parametrize(
-    "pipeline_config_data,pipeline_class,n_files_expected",
+    "pipeline_config_data,pipeline_class,n_files_expected,strict",
     [
-        ({"STEPS": [{}]}, BasePipelineConfig, 0),
+        ({"STEPS": [{}]}, BasePipelineConfig, 0, False),
         (
             {
                 "STEPS": [
@@ -250,6 +250,7 @@ def test_check_pybids_ignore_file_invalid(fpath, exception_class, exception_mess
             },
             BIDSificationPipelineConfig,
             3,
+            False,
         ),
         (
             {
@@ -266,6 +267,7 @@ def test_check_pybids_ignore_file_invalid(fpath, exception_class, exception_mess
             },
             ProcessingPipelineConfig,
             5,
+            True,
         ),
         (
             {
@@ -293,22 +295,37 @@ def test_check_pybids_ignore_file_invalid(fpath, exception_class, exception_mess
             },
             ExtractionPipelineConfig,
             8,
+            True,
         ),
     ],
 )
-def test_check_config_files(
-    pipeline_config_data, pipeline_class, n_files_expected, valid_config_data
+def test_check_pipeline_files(
+    pipeline_config_data,
+    pipeline_class,
+    n_files_expected,
+    valid_config_data,
+    strict,
+    mocker: pytest_mock.MockFixture,
 ):
+    mocked_check_descriptor_file = mocker.patch(
+        "nipoppy.pipeline_validation._check_descriptor_file",
+        wraps=_check_descriptor_file,
+    )
+
     pipeline_config = pipeline_class(**pipeline_config_data, **valid_config_data)
-    files = _check_pipeline_files(pipeline_config, DPATH_TEST_DATA)
+    files = _check_pipeline_files(pipeline_config, DPATH_TEST_DATA, strict=strict)
 
     # check that the function returns the expected number of files
     assert isinstance(files, list)
     assert n_files_expected == len(files)
 
+    if n_files_expected > 0:
+        mocked_check_descriptor_file.assert_called()
+        assert mocked_check_descriptor_file.call_args[1].get("strict") == strict
+
 
 @pytest.mark.no_xdist
-def test_check_config_files_logging(
+def test_check_pipeline_files_logging(
     valid_config_data,
     caplog: pytest.LogCaptureFixture,
 ):
@@ -403,9 +420,12 @@ def test_check_no_subdirectories_logging(
     assert all([record.levelno == log_level for record in caplog.records])
 
 
-@pytest.mark.parametrize("log_level", [logging.DEBUG, logging.INFO, logging.WARNING])
+@pytest.mark.parametrize(
+    "log_level,strict",
+    [(logging.DEBUG, False), (logging.INFO, True), (logging.WARNING, False)],
+)
 def test_check_pipeline_bundle(
-    log_level: int, valid_config_data, mocker: pytest_mock.MockFixture
+    log_level: int, strict: bool, valid_config_data, mocker: pytest_mock.MockFixture
 ):
     dpath_bundle = Path("bundle_dir").resolve()
     config = BasePipelineConfig(**valid_config_data)
@@ -426,13 +446,13 @@ def test_check_pipeline_bundle(
         "nipoppy.pipeline_validation._check_no_subdirectories"
     )
 
-    check_pipeline_bundle(dpath_bundle, log_level=log_level)
+    check_pipeline_bundle(dpath_bundle, log_level=log_level, strict=strict)
 
     mocked_load_pipeline_config_file.assert_called_once_with(
         dpath_bundle / "config.json"
     )
     mocked_check_pipeline_files.assert_called_once_with(
-        config, dpath_bundle, log_level=log_level
+        config, dpath_bundle, log_level=log_level, strict=strict
     )
     mocked_check_self_contained.assert_called_once_with(dpath_bundle, fpaths)
     mocked_check_no_subdirectories.assert_called_once_with(dpath_bundle)

--- a/tests/unit/test_pipeline_validation.py
+++ b/tests/unit/test_pipeline_validation.py
@@ -84,9 +84,23 @@ def test_load_pipeline_config_file_invalid(fpath, exception_class, exception_mes
         _load_pipeline_config_file(fpath)
 
 
-def test_check_descriptor_file():
+def test_check_descriptor_file(caplog: pytest.LogCaptureFixture):
     assert isinstance(
         _check_descriptor_file(DPATH_TEST_DATA / "descriptor-valid.json"), str
+    )
+    assert len(caplog.records) == 0
+
+
+def test_check_descriptor_file_warning(caplog: pytest.LogCaptureFixture):
+
+    _check_descriptor_file(DPATH_TEST_DATA / "descriptor-deprecated.json")
+
+    assert any(
+        [
+            record.levelno == logging.WARNING
+            and "no longer be supported" in record.message
+            for record in caplog.records
+        ]
     )
 
 

--- a/tests/unit/test_pipeline_validation.py
+++ b/tests/unit/test_pipeline_validation.py
@@ -98,7 +98,7 @@ def test_check_descriptor_file_deprecation_warning(caplog: pytest.LogCaptureFixt
     assert any(
         [
             record.levelno == logging.WARNING
-            and "no longer be supported" in record.message
+            and "This will be deprecated in the future" in record.message
             for record in caplog.records
         ]
     )

--- a/tests/unit/workflows/pipeline_store/test_upload.py
+++ b/tests/unit/workflows/pipeline_store/test_upload.py
@@ -28,7 +28,7 @@ def workflow(mocker: pytest_mock.MockerFixture):
     return workflow
 
 
-def test_upload(workflow: PipelineUploadWorkflow, mocker: pytest_mock.MockerFixture):
+def test_run_main(workflow: PipelineUploadWorkflow, mocker: pytest_mock.MockerFixture):
     metadata = {"metadata": {}}
     get_pipeline_metadata = mocker.patch.object(
         workflow, "_get_pipeline_metadata", return_value=metadata
@@ -48,7 +48,7 @@ def test_upload(workflow: PipelineUploadWorkflow, mocker: pytest_mock.MockerFixt
         default_preview_filename=DatasetLayout.fname_pipeline_config,
     )
     get_pipeline_metadata.assert_called_once()
-    validator.assert_called_once()
+    validator.assert_called_once_with(TEST_PIPELINE, strict=True)
 
 
 def test_get_pipeline_metadata(

--- a/tests/unit/workflows/pipeline_store/test_validate.py
+++ b/tests/unit/workflows/pipeline_store/test_validate.py
@@ -27,7 +27,9 @@ def test_run_main(
     )
     workflow.run_main()
 
-    mocked.assert_called_once_with(workflow.dpath_pipeline, log_level=logging.INFO)
+    mocked.assert_called_once_with(
+        workflow.dpath_pipeline, log_level=logging.INFO, strict=True
+    )
 
     assert "Validating pipeline at" in caplog.text
     assert "The pipeline files are all valid" in caplog.text


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->

<!-- Add issue number -->
- Closes #771
<!-- - Related to # -->

<!-- Summarize proposed changes below -->
## Changes
- "Old descriptors" refer to those that have Nipoppy-specific components in the `"command-line"` field
- `nipoppy pipeline upload/validate` will no longer work with old descriptors
- `nipoppy pipeline install` will work as before but emit a deprecation warning

<!-- DO NOT EDIT OR REMOVE -->
## Checklist
_This section is for the PR reviewer_

### All PRs
- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

### If new feature
- [ ] Tests have been added

### If bug fix
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--1013.org.readthedocs.build/en/1013/

<!-- readthedocs-preview nipoppy end -->