### PR TITLE
[BUG] Throw error if substitution value is not a string

### DIFF
--- a/nipoppy/utils/utils.py
+++ b/nipoppy/utils/utils.py
@@ -14,7 +14,7 @@ from nipoppy.env import (
     NIPOPPY_DIR_NAME,
     StrOrPathLike,
 )
-from nipoppy.exceptions import NipoppyError
+from nipoppy.exceptions import ConfigError, NipoppyError
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -249,6 +249,10 @@ def apply_substitutions_to_json(
     # convert json_obj to string
     json_text = json.dumps(json_obj)
     for key, value in substitutions.items():
+        if not isinstance(value, str):
+            raise ConfigError(
+                f"Substitution target must be a string, got {type(value)} for key {key}"
+            )
         json_text = json_text.replace(key, value)
     return json.loads(json_text)
 

--- a/nipoppy/utils/utils.py
+++ b/nipoppy/utils/utils.py
@@ -251,7 +251,7 @@ def apply_substitutions_to_json(
     for key, value in substitutions.items():
         if not isinstance(value, str):
             raise ConfigError(
-                f"Substitution target must be a string, got {type(value)} for key '{key}'"  # noqa: E501
+                f"Substitution value must be a string, got {type(value)} for key '{key}'"  # noqa: E501
             )
         json_text = json_text.replace(key, value)
     return json.loads(json_text)

--- a/nipoppy/utils/utils.py
+++ b/nipoppy/utils/utils.py
@@ -251,7 +251,7 @@ def apply_substitutions_to_json(
     for key, value in substitutions.items():
         if not isinstance(value, str):
             raise ConfigError(
-                f"Substitution target must be a string, got {type(value)} for key {key}"
+                f"Substitution target must be a string, got {type(value)} for key '{key}'"  # noqa: E501
             )
         json_text = json_text.replace(key, value)
     return json.loads(json_text)

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -7,7 +7,7 @@ from typing import Optional
 import pandas as pd
 import pytest
 
-from nipoppy.exceptions import NipoppyError
+from nipoppy.exceptions import ConfigError, NipoppyError
 from nipoppy.layout import DatasetLayout
 from nipoppy.utils.utils import (
     add_path_suffix,
@@ -202,6 +202,11 @@ def test_process_template_str_error_replace():
 )
 def test_apply_substitutions_to_json(json_obj, substitutions, expected_output):
     assert apply_substitutions_to_json(json_obj, substitutions) == expected_output
+
+
+def test_apply_substitutions_to_json_invalid_value():
+    with pytest.raises(ConfigError, match="Substitution target must be a string"):
+        apply_substitutions_to_json({"key1": "TO_REPLACE"}, {"TO_REPLACE": None})
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -205,7 +205,7 @@ def test_apply_substitutions_to_json(json_obj, substitutions, expected_output):
 
 
 def test_apply_substitutions_to_json_invalid_value():
-    with pytest.raises(ConfigError, match="Substitution target must be a string"):
+    with pytest.raises(ConfigError, match="Substitution value must be a string"):
         apply_substitutions_to_json({"key1": "TO_REPLACE"}, {"TO_REPLACE": None})
 
 


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->

<!-- Add issue number -->
- Closes #972
<!-- - Related to # -->

<!-- Summarize proposed changes below -->
## Changes
- Throw a `ConfigError` if substitution value is not a string

<!-- DO NOT EDIT OR REMOVE -->
## Checklist
_This section is for the PR reviewer_

### All PRs
- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

### If new feature
- [ ] Tests have been added

### If bug fix
- [x] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--1016.org.readthedocs.build/en/1016/

<!-- readthedocs-preview nipoppy end -->