### PR TITLE
[ENH] Warn when participant ID still starts with 'sub' after stripping prefix

### DIFF
--- a/nipoppy/utils/bids.py
+++ b/nipoppy/utils/bids.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Sequence
 
@@ -71,6 +72,16 @@ def check_participant_id(participant_id: Optional[str], raise_error=False):
         raise NipoppyError(
             f"Invalid participant ID: must only contain alphanumeric characters, "
             f"got {participant_id}"
+        )
+
+    if participant_id.lower().startswith("sub"):
+        warnings.warn(
+            "One or more participant IDs in the manifest still start with 'sub' "
+            "after the BIDS 'sub-' prefix has been stripped (e.g. 'sub-sub123' or "
+            "'sub123'). This is likely unintentional — manifest participant IDs "
+            "should not contain the BIDS prefix.",
+            UserWarning,
+            stacklevel=2,
         )
 
     return participant_id

--- a/tests/unit/utils/test_bids.py
+++ b/tests/unit/utils/test_bids.py
@@ -1,6 +1,7 @@
 """Tests for the utils.bids module."""
 
 import re
+import warnings
 from contextlib import nullcontext
 from pathlib import Path
 
@@ -55,6 +56,22 @@ def test_check_participant_id(participant_id, raise_error, is_valid, expected):
         output = check_participant_id(participant_id, raise_error=raise_error)
         if is_valid:
             assert output == expected
+
+
+@pytest.mark.parametrize(
+    "participant_id,expected",
+    [("sub-sub123", "sub123"), ("sub123", "sub123"), ("SUB01", "SUB01")],
+)
+def test_check_participant_id_warns_on_sub_prefix(participant_id, expected):
+    with pytest.warns(UserWarning, match="still start with 'sub'"):
+        assert check_participant_id(participant_id) == expected
+
+
+@pytest.mark.parametrize("participant_id", ["01", "sub-01", "P01", None])
+def test_check_participant_id_no_warning(participant_id):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        check_participant_id(participant_id)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Closes #559

## Changes

`check_participant_id` now emits a `UserWarning` when the ID still starts with `sub` after the BIDS `sub-` prefix has been stripped. Catches the two common slip-ups from the issue:

- `sub-sub123` → stripped to `sub123` → warns
- `sub123` (no dash) → no strip → warns

The warning message is intentionally generic (it doesn't include the offending ID), so Python's default warnings filter deduplicates it by `(message, module, lineno)`. A manifest with 500 problematic IDs produces **one** warning, not 500 — addresses @michellewang's concern in the issue thread.

Plain IDs (`01`, `P01`, `sub-01`) are unaffected.

Tests added:
- `test_check_participant_id_warns_on_sub_prefix` — covers `sub-sub123`, `sub123`, `SUB01` (case-insensitive)
- `test_check_participant_id_no_warning` — covers `01`, `sub-01`, `P01`, `None` (turns `UserWarning` into an error to assert silence)

<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--1019.org.readthedocs.build/en/1019/

<!-- readthedocs-preview nipoppy end -->