### PR TITLE
[MAINT] Add snapshot test to prevent emphasize-lines drift in sample_global_config.json

### DIFF
--- a/tests/docs/sample_global_config-snapshot.json
+++ b/tests/docs/sample_global_config-snapshot.json
@@ -1,0 +1,34 @@
+{
+    "SUBSTITUTIONS": {
+        "_comment": "Self-references like NIPOPPY_DPATH_CONTAINERS are resolved from the layout at runtime, making them layout-aware",
+        "[[NIPOPPY_DPATH_CONTAINERS]]": "[[NIPOPPY_DPATH_CONTAINERS]]",
+        "[[HPC_ACCOUNT_NAME]]": ""
+    },
+    "DICOM_DIR_PARTICIPANT_FIRST": true,
+    "CONTAINER_CONFIG": {
+        "COMMAND": "apptainer",
+        "ARGS": [
+            "--cleanenv"
+        ],
+        "BIND_PATHS": [],
+        "ENV_VARS": {
+            "PYTHONUNBUFFERED": "1"
+        }
+    },
+    "HPC_PREAMBLE": [
+        "# (These lines can all be removed if not using HPC functionality.)",
+        "# ========== Activate Python environment ==========",
+        "# Here we need the command to activate your Python environment in an ",
+        "# HPC job, for example:",
+        "# - venv:  source <PATH_TO_VENV>/bin/activate",
+        "# - conda: source ~/.bashrc; conda activate <ENV_NAME>",
+        "# ========== Set environment variables ==========",
+        "export PYTHONUNBUFFERED=1"
+    ],
+    "PIPELINE_VARIABLES": {
+        "BIDSIFICATION": {},
+        "PROCESSING": {},
+        "EXTRACTION": {}
+    },
+    "CUSTOM": {}
+}

--- a/tests/docs/test_sample_config_snapshot.py
+++ b/tests/docs/test_sample_config_snapshot.py
@@ -1,0 +1,39 @@
+"""Snapshot test for sample_global_config.json.
+
+Several docs pages pull this file in with ``literalinclude`` and
+``emphasize-lines`` pointing at specific line numbers. When the live file
+changes, the highlighted lines can silently drift out of sync. This test
+fails on any mismatch so a contributor remembers to update both the
+snapshot and the affected docs pages.
+
+Pages currently referencing ``sample_global_config.json`` with
+``emphasize-lines``:
+
+- ``docs/source/how_to_guides/parallelization/hpc_scheduler.md``
+- ``docs/source/how_to_guides/docker/index.md``
+- ``docs/source/tutorials/mriqc_from_bids/index.md``
+- ``docs/source/overview/quickstart/index.md``
+"""
+
+from pathlib import Path
+
+LIVE_FILE = (
+    Path(__file__).parents[2]
+    / "nipoppy"
+    / "data"
+    / "examples"
+    / "sample_global_config.json"
+)
+SNAPSHOT_FILE = Path(__file__).parent / "sample_global_config-snapshot.json"
+
+
+def test_sample_global_config_matches_snapshot():
+    live = LIVE_FILE.read_text()
+    snapshot = SNAPSHOT_FILE.read_text()
+    assert live == snapshot, (
+        f"{LIVE_FILE.name} has changed but the docs snapshot at "
+        f"{SNAPSHOT_FILE.relative_to(Path(__file__).parents[2])} hasn't been "
+        "updated. Update the snapshot copy and double-check that the "
+        "`emphasize-lines` directives in the docs pages still point at the "
+        "right lines (and that the surrounding prose still makes sense)."
+    )


### PR DESCRIPTION
- Closes #990

## Changes

Per the plan in the issue thread (with @michellewang and @mathdugre's preference for a test rather than a heuristic), this PR adds:

- `tests/docs/sample_global_config-snapshot.json` — reference copy of the live `nipoppy/data/examples/sample_global_config.json`
- `tests/docs/test_sample_config_snapshot.py` — single test that compares the two files byte-for-byte; fails with a message that prompts the contributor to refresh the snapshot **and** double-check that the `emphasize-lines` directives in the affected docs pages still point at the right lines.

Pages currently using `literalinclude` + `emphasize-lines` against this file (listed in the test docstring): `hpc_scheduler.md`, `docker/index.md`, `tutorials/mriqc_from_bids/index.md`, `overview/quickstart/index.md`.

Scope is intentionally just `sample_global_config.json` — the file with the most drift surface area (referenced from 4 doc pages). Other sample configs (`fmriprep_config.json`, `mriqc_config.json`, inline configs) can follow in a separate PR if useful.

I verified the failure path locally by appending a key to the live file and confirming the test fails with the diff and the custom message; restoring the file makes the test pass again.

<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--1020.org.readthedocs.build/en/1020/

<!-- readthedocs-preview nipoppy end -->