### PR TITLE
[MAINT] Make dotenv file locations non-configurable

### DIFF
--- a/docs/source/how_to_guides/configuration/index.md
+++ b/docs/source/how_to_guides/configuration/index.md
@@ -8,14 +8,9 @@ Some {term}`CLI` options, such as `--layout`, can be configured via environment 
 This will be indicated in the usage message when running `nipoppy <SUBCOMMAND> --help`.
 
 It is also possible to set these options using `.env` environment files.
-By default, Nipoppy searches the following locations (in order of decreasing priority):
-1. {{dpath_root}}`/.env`: project-level
+Nipoppy searches the following locations (in order of decreasing priority):
+1. {{dpath_root}}`/.nipoppy/.env`: project-level
 2. `~/.nipoppy/.env`: user-level
-3. `/etc/nipoppy/.env`: system-level
-
-The search paths can be overridden by setting the `NIPOPPY_ENV_PATHS` environment variable with paths separated by the platform path separator
-(e.g., `export NIPOPPY_ENV_PATHS="[[NIPOPPY_DPATH_ROOT]]/.env:~/.nipoppy/.env:/etc/nipoppy/.env"` for the default paths).
-Only the `[[NIPOPPY_DPATH_ROOT]]` substitution is allowed here.
 
 The overall order for determining the value of options is as follows (highest to lowest priority):
 1. Command-line options that are explicitly passed when calling the command

--- a/docs/source/how_to_guides/configuration/index.md
+++ b/docs/source/how_to_guides/configuration/index.md
@@ -9,7 +9,7 @@ This will be indicated in the usage message when running `nipoppy <SUBCOMMAND> -
 
 It is also possible to set these options using `.env` environment files.
 Nipoppy searches the following locations (in order of decreasing priority):
-1. {{dpath_root}}`/.nipoppy/.env`: project-level
+1. {{dpath_root}}`/.env`: project-level
 2. `~/.nipoppy/.env`: user-level
 
 The overall order for determining the value of options is as follows (highest to lowest priority):

--- a/nipoppy/cli/groups.py
+++ b/nipoppy/cli/groups.py
@@ -1,27 +1,30 @@
 """Custom Click groups."""
 
-import os
+from collections.abc import Iterable
 from pathlib import Path
 
 import rich_click as click
 from dotenv import load_dotenv
 
 from nipoppy.cli.options import dataset_option
-from nipoppy.env import DEFAULT_DOTENV_PATHS, DOTENV_PATHS_VAR
+from nipoppy.env import DEFAULT_DOTENV_PATHS
 from nipoppy.logger import get_logger
 from nipoppy.utils.utils import is_nipoppy_project, process_template_str
 
 logger = get_logger()
 
 
-def _load_dotenv_files(dpath_root: Path):
+def _load_dotenv_files(
+    dpath_root: Path, fpaths_dotenv: Iterable[str] = DEFAULT_DOTENV_PATHS
+):
     """Load .env files."""
     dpath_root = is_nipoppy_project(dpath_root) or dpath_root
 
-    fpaths_dotenv_str = os.environ.get(DOTENV_PATHS_VAR, DEFAULT_DOTENV_PATHS)
-    fpaths_dotenv_str = process_template_str(fpaths_dotenv_str, dpath_root=dpath_root)
-
-    for fpath_dotenv in fpaths_dotenv_str.split(os.pathsep):
+    for fpath_dotenv in fpaths_dotenv:
+        fpath_dotenv = process_template_str(
+            fpath_dotenv,
+            dpath_root=dpath_root,
+        )
         fpath_dotenv = Path(fpath_dotenv).expanduser()
         if fpath_dotenv.is_file():
             # the logger only logs at INFO or higher at this point

--- a/nipoppy/env.py
+++ b/nipoppy/env.py
@@ -32,13 +32,7 @@ EXT_LOG = ".log"
 
 # dotenv files
 # from highest to lowest priority
-DEFAULT_DOTENV_PATHS_LIST = [
-    "[[NIPOPPY_DPATH_ROOT]]/.env",
-    "~/.nipoppy/.env",
-    "/etc/nipoppy/.env",
-]
-DOTENV_PATHS_VAR = "NIPOPPY_ENV_PATHS"
-DEFAULT_DOTENV_PATHS = os.pathsep.join(DEFAULT_DOTENV_PATHS_LIST)
+DEFAULT_DOTENV_PATHS = ("[[NIPOPPY_DPATH_ROOT]]/.env", "~/.nipoppy/.env")
 
 
 class ContainerCommandEnum(str, Enum):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -604,53 +604,53 @@ def test_cli_params_match_workflows(command_name):
     [
         (
             "subcommand-with-dataset",
-            "TEST_PARAM='dotenv_global'",
-            "TEST_PARAM='dotenv_local'",
+            "TEST_PARAM='user_dotenv'",
+            "TEST_PARAM='study_dotenv'",
             {"TEST_PARAM": "env_var"},
             ["--test-param", "cli_arg"],
             "cli_arg",
         ),
         (
             "subcommand-with-dataset",
-            "TEST_PARAM='dotenv_global'",
-            "TEST_PARAM='dotenv_local'",
+            "TEST_PARAM='user_dotenv'",
+            "TEST_PARAM='study_dotenv'",
             {"TEST_PARAM": "env_var"},
             [],
             "env_var",
         ),
         (
             "subcommand-with-dataset",
-            "TEST_PARAM='dotenv_global'",
-            "TEST_PARAM='dotenv_local'",
+            "TEST_PARAM='user_dotenv'",
+            "TEST_PARAM='study_dotenv'",
             {},
             [],
-            "dotenv_local",
+            "study_dotenv",
         ),
         (
             "subcommand-with-dataset",
-            "TEST_PARAM='dotenv_global'",
+            "TEST_PARAM='user_dotenv'",
             "",
             {},
             [],
-            "dotenv_global",
+            "user_dotenv",
         ),
         (
             "subcommand-with-dataset",
-            "TEST_PARAM='dotenv_global'",
+            "TEST_PARAM='user_dotenv'",
             None,
             {},
             [],
-            "dotenv_global",
+            "user_dotenv",
         ),
         ("subcommand-with-dataset", "", None, {}, [], DEFAULT_VALUE_DUMMY_CLI),
         ("subcommand-with-dataset", None, None, {}, [], DEFAULT_VALUE_DUMMY_CLI),
         (
             "subcommand-without-dataset",
-            "TEST_PARAM='dotenv_global'",
-            "TEST_PARAM='dotenv_local'",  # ignored
+            "TEST_PARAM='user_dotenv'",
+            "TEST_PARAM='study_dotenv'",  # ignored
             {},
             [],
-            "dotenv_global",
+            "user_dotenv",
         ),
     ],
 )
@@ -670,18 +670,18 @@ def test_param_source_priority(
 
     # user-level dotenv at ~/.nipoppy/.env
     dpath_home = tmp_path / "home"
-    fpath_dotenv_global = dpath_home / ".nipoppy" / ".env"
+    fpath_user_dotenv = dpath_home / ".nipoppy" / ".env"
 
     # study-level dotenv at [[NIPOPPY_DPATH_ROOT]]/.env
-    fpath_dotenv_local = dpath_root / ".env"
+    fpath_study_dotenv = dpath_root / ".env"
 
     if user_dotenv_content is not None:
-        fpath_dotenv_global.parent.mkdir(parents=True, exist_ok=True)
-        fpath_dotenv_global.write_text(user_dotenv_content)
+        fpath_user_dotenv.parent.mkdir(parents=True, exist_ok=True)
+        fpath_user_dotenv.write_text(user_dotenv_content)
 
     if study_dotenv_content is not None:
-        fpath_dotenv_local.parent.mkdir(parents=True, exist_ok=True)
-        fpath_dotenv_local.write_text(study_dotenv_content)
+        fpath_study_dotenv.parent.mkdir(parents=True, exist_ok=True)
+        fpath_study_dotenv.write_text(study_dotenv_content)
 
     # set HOME so ~ expands to the test home directory
     monkeypatch.setenv("HOME", str(dpath_home))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,7 +6,6 @@ import importlib
 import inspect
 import json
 import logging
-import os
 import shlex
 from pathlib import Path
 
@@ -23,7 +22,6 @@ from nipoppy.cli import (
 from nipoppy.cli.cli import cli
 from nipoppy.cli.groups import OrderedAliasedGroupWithDotenv
 from nipoppy.cli.options import dataset_option
-from nipoppy.env import DOTENV_PATHS_VAR
 from nipoppy.exceptions import JSONError, NipoppyError, ReturnCode
 from tests.conftest import PASSWORD_FILE, list_cli_commands
 
@@ -602,7 +600,7 @@ def test_cli_params_match_workflows(command_name):
 
 
 @pytest.mark.parametrize(
-    "subcommand,dotenv_global_content,dotenv_local_content,env_vars,cli_args,expected_parsed_param",  # noqa: E501
+    "subcommand,user_dotenv_content,study_dotenv_content,env_vars,cli_args,expected_parsed_param",  # noqa: E501
     [
         (
             "subcommand-with-dataset",
@@ -659,31 +657,34 @@ def test_cli_params_match_workflows(command_name):
 def test_param_source_priority(
     dummy_cli: click.Group,
     subcommand: str,
-    dotenv_global_content,
-    dotenv_local_content,
+    user_dotenv_content,
+    study_dotenv_content,
     env_vars,
     cli_args,
     expected_parsed_param: str,
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
     restore_environment,
 ):
     dpath_root = tmp_path / "nipoppy_root"
 
-    fpath_dotenv_global = tmp_path / "dotenv_global.env"
-    fpath_dotenv_local = dpath_root / "dotenv_local.env"
-    fpath_dotenv_local_template = "[[NIPOPPY_DPATH_ROOT]]/dotenv_local.env"
+    # user-level dotenv at ~/.nipoppy/.env
+    dpath_home = tmp_path / "home"
+    fpath_dotenv_global = dpath_home / ".nipoppy" / ".env"
 
-    if dotenv_global_content is not None:
-        fpath_dotenv_global.write_text(dotenv_global_content)
+    # study-level dotenv at [[NIPOPPY_DPATH_ROOT]]/.env
+    fpath_dotenv_local = dpath_root / ".env"
 
-    if dotenv_local_content is not None:
+    if user_dotenv_content is not None:
+        fpath_dotenv_global.parent.mkdir(parents=True, exist_ok=True)
+        fpath_dotenv_global.write_text(user_dotenv_content)
+
+    if study_dotenv_content is not None:
         fpath_dotenv_local.parent.mkdir(parents=True, exist_ok=True)
-        fpath_dotenv_local.write_text(dotenv_local_content)
+        fpath_dotenv_local.write_text(study_dotenv_content)
 
-    # local dotenv has higher priority than global dotenv
-    env_vars[DOTENV_PATHS_VAR] = os.pathsep.join(
-        [str(fpath_dotenv_local_template), str(fpath_dotenv_global)]
-    )
+    # set HOME so ~ expands to the test home directory
+    monkeypatch.setenv("HOME", str(dpath_home))
 
     if subcommand == "subcommand-with-dataset":
         cli_args += ["--dataset", str(dpath_root)]


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->

<!-- Add issue number -->
- Closes #1035
<!-- - Related to # -->

<!-- Summarize proposed changes below -->
## Changes
- Do not allow users to configure where the dotenv files are. Only check `~/.nipoppy/.env` and `<NIPOPPY_ROOT>/.env`
- Update docs

<!-- DO NOT EDIT OR REMOVE -->
## Checklist
_This section is for the PR reviewer_

### All PRs
- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

### If new feature
- [ ] Tests have been added

### If bug fix
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--1036.org.readthedocs.build/en/1036/

<!-- readthedocs-preview nipoppy end -->