### PR TITLE
fix: skip file operations in run_cleanup when --simulate is used (Fixes #1046)

### DIFF
--- a/nipoppy/workflows/processing_runner.py
+++ b/nipoppy/workflows/processing_runner.py
@@ -222,7 +222,9 @@ class ProcessingRunner(Runner):
 
     def run_cleanup(self):
         """Run pipeline runner cleanup."""
-        if self.n_success == self.n_total:
+        if self.simulate:
+            logger.info("Simulated run — skipping cleanup of working directories.")
+        elif self.n_success == self.n_total:
             if not self.keep_workdir:
                 for dpath in [self.dpath_pipeline_bids_db, self.dpath_pipeline_work]:
                     if dpath.exists():

--- a/tests/unit/workflows/test_processing_runner.py
+++ b/tests/unit/workflows/test_processing_runner.py
@@ -165,6 +165,19 @@ def test_run_failed_cleanup(runner: ProcessingRunner, n_success):
         assert dpath.exists()
 
 
+def test_run_cleanup_simulate(runner: ProcessingRunner):
+    """Test that simulate mode skips file deletion in cleanup."""
+    runner.simulate = True
+    runner.keep_workdir = False
+    dpaths = [runner.dpath_pipeline_bids_db, runner.dpath_pipeline_work]
+    for dpath in dpaths:
+        dpath.mkdir(parents=True)
+    runner.run_cleanup()
+    # Directories should still exist when simulating
+    for dpath in dpaths:
+        assert dpath.exists()
+
+
 @pytest.mark.parametrize("simulate", [True, False])
 def test_launch_boutiques_run(
     simulate, runner: ProcessingRunner, mocker: pytest_mock.MockFixture


### PR DESCRIPTION
Fixes #1046

## Problem

When using `nipoppy process --simulate`, the `run_cleanup` method in `ProcessingRunner` still attempts to delete pipeline working directories (`dpath_pipeline_bids_db`, `dpath_pipeline_work`). This happens because the cleanup only checks `self.dry_run` but not `self.simulate` — and these are independent CLI flags.

This causes a `PermissionError` when the working directory contains read-only files (like `_node.pklz`), since `shutil.rmtree` tries to actually delete them even in simulate mode.

## Root Cause

In `nipoppy/workflows/processing_runner.py`, the `run_cleanup` method used `dry_run=self.dry_run` for the file deletion call, but `self.simulate` was never checked. The `bids_conversion.py` module already correctly handles this scenario (line 137: `if self.pipeline_step_config.UPDATE_STATUS and not self.simulate:`), but `processing_runner.py` did not.

## Fix

Added a `self.simulate` check at the top of `run_cleanup`. When simulating, the method logs an informational message and skips all file operations — consistent with how `bids_conversion.py` handles the same scenario.

## Verification

All existing cleanup tests pass, plus a new test `test_run_cleanup_simulate` verifies that directories are preserved during simulate mode:

```
tests/unit/workflows/test_processing_runner.py::test_run_cleanup_simulate PASSED
tests/unit/workflows/test_processing_runner.py::test_run_cleanup[True] PASSED
tests/unit/workflows/test_processing_runner.py::test_run_cleanup[False] PASSED
tests/unit/workflows/test_processing_runner.py::test_run_failed_cleanup[1] PASSED
tests/unit/workflows/test_processing_runner.py::test_run_failed_cleanup[2] PASSED
```

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--1047.org.readthedocs.build/en/1047/

<!-- readthedocs-preview nipoppy end -->