### PR TITLE
[DOC] Improve documentation on Docker support

### DIFF
--- a/docs/source/how_to_guides/configuration/index.md
+++ b/docs/source/how_to_guides/configuration/index.md
@@ -18,6 +18,7 @@ The overall order for determining the value of options is as follows (highest to
 3. Environment variables loaded from `.env` file(s) (see above)
 4. CLI default values
 
+(default-config-override)=
 ## Overriding the global configuration file
 
 The default configuration file created by `nipoppy init` can be overridden by creating a user-level configuration file at {{fpath_user_config}}. This can enable the setting of certain machine- or user-specific fields, such as the container command. It can also allow the pre-definition of variables for common pipelines.

--- a/docs/source/how_to_guides/docker/fmriprep_config.json
+++ b/docs/source/how_to_guides/docker/fmriprep_config.json
@@ -9,14 +9,10 @@
         "ENV_VARS": {
             "TEMPLATEFLOW_HOME": "[[TEMPLATEFLOW_HOME]]"
         },
-        "ARGS": [
-            "--bind",
+        "BIND_PATHS": [
             "[[FREESURFER_LICENSE_FILE]]",
-            "--bind",
             "[[TEMPLATEFLOW_HOME]]",
-            "--bind",
             "[[NIPOPPY_DPATH_PIPELINE_WORK]]:/work",
-            "--bind",
             "[[NIPOPPY_DPATH_DERIVATIVES]]/freesurfer/7.3.2/output/[[NIPOPPY_BIDS_SESSION_ID]]"
         ]
     },

--- a/docs/source/how_to_guides/docker/index.md
+++ b/docs/source/how_to_guides/docker/index.md
@@ -10,7 +10,7 @@ The following changes need to be made to the `"CONTAINER_CONFIG"` field of the `
 - `"COMMAND"` should be set to `"docker"` instead of `"apptainer"`
 - Any non-Docker argument/option should be removed from `"ARGS"`
     - In particular, the default `global_config.json` uses the `"--cleanenv"` argument, which is specific to Apptainer and needs to be removed if using Docker.
-    - Any user-specific bind paths also need to be changed to `--volume` instead of `--bind`. The target (destination) path also needs to be explicitly specified (e.g. `--volume /source:/target` instead of `--volume`). If using Nipoppy 0.4.6 or later, use the new dedicated `"BIND_PATHS"` field instead as it is agnostic to the container platform.
+    - Any user-specific bind paths also need to be changed to `--volume` instead of `--bind`. The target (destination) path also needs to be explicitly specified (e.g. `--volume /source:/target` instead of `--volume`). **If using Nipoppy 0.4.6 or later, use the new dedicated `"BIND_PATHS"` field instead as it is agnostic to the container platform.**
 
 ```{literalinclude} ../../../../nipoppy/data/examples/sample_global_config.json
 ---
@@ -26,7 +26,7 @@ Similarly to `global_config.json`, pipeline-specific `config.json` files also ha
 They can appear at the top level or inside individual step configurations.
 The same changes described above need to be applied to these `"CONTAINER_CONFIG"` fields.
 Most commonly, bind paths need to be changed to `--volume` instead of `--bind`, and the target (destination) path needs to be explicitly specified (e.g. `--volume /source:/target` instead of `--volume`).
-If using Nipoppy 0.4.6 or later, use the new dedicated `"BIND_PATHS"` field instead as it is agnostic to the container platform.
+**If using Nipoppy 0.4.6 or later, use the new dedicated `"BIND_PATHS"` field instead as it is agnostic to the container platform.**
 
 ```{literalinclude} ./fmriprep_config.json
 ---

--- a/docs/source/how_to_guides/docker/index.md
+++ b/docs/source/how_to_guides/docker/index.md
@@ -9,7 +9,7 @@ The following changes need to be made to the `"CONTAINER_CONFIG"` field of the `
 - Any non-Docker argument/option should be removed from `"ARGS"`
     - In particular, the default `global_config.json` uses the `"--cleanenv"` argument, which is specific to Apptainer and needs to be removed if using Docker.
 
-```tip
+```{tip}
 To avoid having to manually make these changes for every new Nipoppy study, you can set a custom configuration file at {{fpath_user_config}} to be used instead of the default one below.
 See {ref}`here <default-config-override>` for more information.
 ```

--- a/docs/source/how_to_guides/docker/index.md
+++ b/docs/source/how_to_guides/docker/index.md
@@ -1,8 +1,6 @@
 # Using Nipoppy with Docker
 
-This guide describes the steps required to run Nipoppy with {term}`Docker`.
-
-By default, Nipoppy will try to use {term}`Apptainer`, but support for {term}`Docker` was added in version [0.4.2](https://github.com/nipoppy/nipoppy/releases/tag/0.4.2).
+This guide describes the steps required to run Nipoppy with the {term}`Docker` container engine, for which support was added in version [0.4.2](https://github.com/nipoppy/nipoppy/releases/tag/0.4.2).
 
 ## Study-level configuration
 
@@ -11,10 +9,9 @@ The following changes need to be made to the `"CONTAINER_CONFIG"` field of the `
 - Any non-Docker argument/option should be removed from `"ARGS"`
     - In particular, the default `global_config.json` uses the `"--cleanenv"` argument, which is specific to Apptainer and needs to be removed if using Docker.
 
-```{attention}
-The `"BIND_PATHS"` field was only added in version 0.4.6.
-For older versions of Nipoppy, use the `"ARGS"` with the Docker-specific bind flag `--volume`,
-and make sure to specify explicitly the target (destination) path (e.g. `--volume /source:/target` instead of `--volume /source`).
+```tip
+To avoid having to manually make these changes for every new Nipoppy study, you can set a custom configuration file at {{fpath_user_config}} to be used instead of the default one below.
+See {ref}`here <default-config-override>` for more information.
 ```
 
 ```{literalinclude} ../../../../nipoppy/data/examples/sample_global_config.json
@@ -23,6 +20,12 @@ linenos: True
 language: json
 emphasize-lines: 9,11
 ---
+```
+
+```{attention}
+The `"BIND_PATHS"` field was only added in version 0.4.6.
+For older versions of Nipoppy, use the `"ARGS"` with the Docker-specific bind flag `--volume`,
+and make sure to specify explicitly the target (destination) path (e.g. `--volume /source:/target` instead of `--volume /source`).
 ```
 
 ## Pipeline-level configuration

--- a/docs/source/how_to_guides/docker/index.md
+++ b/docs/source/how_to_guides/docker/index.md
@@ -10,7 +10,12 @@ The following changes need to be made to the `"CONTAINER_CONFIG"` field of the `
 - `"COMMAND"` should be set to `"docker"` instead of `"apptainer"`
 - Any non-Docker argument/option should be removed from `"ARGS"`
     - In particular, the default `global_config.json` uses the `"--cleanenv"` argument, which is specific to Apptainer and needs to be removed if using Docker.
-    - Any user-specific bind paths also need to be changed to `--volume` instead of `--bind`. The target (destination) path also needs to be explicitly specified (e.g. `--volume /source:/target` instead of `--volume`). **If using Nipoppy 0.4.6 or later, use the new dedicated `"BIND_PATHS"` field instead as it is agnostic to the container platform.**
+
+```{attention}
+The `"BIND_PATHS"` field was only added in version 0.4.6.
+For older versions of Nipoppy, use the `"ARGS"` with the Docker-specific bind flag `--volume`,
+and make sure to specify explicitly the target (destination) path (e.g. `--volume /source:/target` instead of `--volume /source`).
+```
 
 ```{literalinclude} ../../../../nipoppy/data/examples/sample_global_config.json
 ---
@@ -25,13 +30,10 @@ emphasize-lines: 9,11
 Similarly to `global_config.json`, pipeline-specific `config.json` files also have `"CONTAINER_CONFIG"` fields.
 They can appear at the top level or inside individual step configurations.
 The same changes described above need to be applied to these `"CONTAINER_CONFIG"` fields.
-Most commonly, bind paths need to be changed to `--volume` instead of `--bind`, and the target (destination) path needs to be explicitly specified (e.g. `--volume /source:/target` instead of `--volume`).
-**If using Nipoppy 0.4.6 or later, use the new dedicated `"BIND_PATHS"` field instead as it is agnostic to the container platform.**
 
 ```{literalinclude} ./fmriprep_config.json
 ---
 linenos: True
 language: json
-emphasize-lines: 13,15,17,19
 ---
 ```

--- a/docs/source/tutorials/mriqc_from_bids/index.md
+++ b/docs/source/tutorials/mriqc_from_bids/index.md
@@ -13,10 +13,6 @@ Concretely, we will:
 If you have not installed Nipoppy yet, instructions are available [here](../../overview/installation).
 ```
 
-```{attention}
-This tutorial assumes that [Apptainer](https://apptainer.org) (or Singularity) is installed on your system. If that is not the case, then you will not be able to run MRIQC with Nipoppy.
-```
-
 ## Step 0: Download the BIDS dataset
 
 We will use the [**ds004101 dataset from OpenNeuro**](https://openneuro.org/datasets/ds004101/versions/1.0.1), which includes structural and functional MRI data for 9 subjects (2 sessions). The dataset can be downloaded by following instructions [here](https://openneuro.org/datasets/ds004101/versions/1.0.1/download). If you do not have DataLad or Node.js installed, you can use the shell script method:
@@ -119,7 +115,7 @@ By default, this file does not contain any pipeline-specific information, since 
 - If Apptainer is not available on your system, you will need to change `CONTAINER_CONFIG` -> `COMMAND` to
     - `"singularity"` if you have Singularity installed
     - `"docker"` if you have Docker installed
-    - `"null"` if you have dcm2bids installed locally ("baremetal" install)
+    - `"null"` if you have MRIQC installed locally ("baremetal" install)
 - If your group uses a shared directory for storing container image files, you can replace the value of `"[[NIPOPPY_DPATH_CONTAINERS]]"` by the full path to that shared directory. For example:
     ```json
     "SUBSTITUTIONS": {
@@ -149,7 +145,7 @@ That is because a newly initialized Nipoppy dataset does not contain any pipelin
 $ nipoppy pipeline install --dataset nipoppy_study {{zenodo_id_mriqc_23_1_0}}
 ```
 
-When running `nipoppy pipeline install`, if using a container engine, you will be asked if you would like to download the dcm2bids container. If you do not already have a download of the container, type `y` and press `Enter` to do so. The download/building process may take ~10 minutes. Apptainer or Singularity container images will be downloaded as `mriqc_23.1.0.sif` inside the container store directory (i.e., `nipoppy_study/containers` or the custom path you set in the `global_config.json` file). Docker images are managed centrally and so will not be downloaded to the dataset.
+When running `nipoppy pipeline install`, if using a container engine, you will be asked if you would like to download the MRIQC container. If you do not already have a download of the container, type `y` and press `Enter` to do so. The download/building process may take ~10 minutes. Apptainer or Singularity container images will be downloaded as `mriqc_23.1.0.sif` inside the container store directory (i.e., `nipoppy_study/containers` or the custom path you set in the `global_config.json` file). Docker images are managed centrally and so will not be downloaded to the dataset.
 
 The pipeline installation process will add a `TEMPLATEFLOW_HOME` pipeline variable to the `nipoppy_study/global_config.json` file:
 


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->

<!-- Add issue number -->
- Closes #1055
- Closes #1038
<!-- - Related to # -->

<!-- Summarize proposed changes below -->
## Changes
- MRIQC tutorial no longer says that only Apptainer or Singularity are supported
- Fix typos in MRIQC tutorial ("dcm2bids" instead of "MRIQC")
- @mathdugre the Docker guide already mentioned "BIND_PATHS", but I put it in bold to make it more obvious. I do think it's still relevant to show the `-v`/`-B` way of doing things since pipeline configs have not all been updated, and not all users are on Nipoppy 0.4.6

<!-- DO NOT EDIT OR REMOVE -->
## Checklist
_This section is for the PR reviewer_

### All PRs
- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

### If new feature
- [ ] Tests have been added

### If bug fix
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--1069.org.readthedocs.build/en/1069/

<!-- readthedocs-preview nipoppy end -->