### PR TITLE
[BUG] Validate descriptor dictionaries directly

### DIFF
--- a/nipoppy/pipeline_validation.py
+++ b/nipoppy/pipeline_validation.py
@@ -5,6 +5,7 @@ import logging
 from pathlib import Path
 
 import boutiques
+from boutiques.validator import validate_descriptor
 from pydantic_core import ValidationError
 
 from nipoppy.config.hpc import HpcConfig
@@ -69,7 +70,7 @@ def _check_descriptor_file(
 
     descriptor_str = json.dumps(descriptor_dict)
     try:
-        boutiques.validate(descriptor_str)
+        validate_descriptor(descriptor_dict)
     except boutiques.DescriptorValidationError as exception:
         raise ConfigError(
             f"Descriptor file {fpath_descriptor} is invalid:\n{exception}"

--- a/tests/unit/test_pipeline_validation.py
+++ b/tests/unit/test_pipeline_validation.py
@@ -1,6 +1,8 @@
 """Tests for the nipoppy.pipeline_validation module."""
 
+import json
 import logging
+import sys
 from contextlib import nullcontext
 from pathlib import Path
 
@@ -84,6 +86,19 @@ def test_check_descriptor_file(caplog: pytest.LogCaptureFixture):
         _check_descriptor_file(DPATH_TEST_DATA / "descriptor-valid.json"), str
     )
     assert len(caplog.records) == 0
+
+
+def test_check_descriptor_file_with_zenodo_tool_doi_without_requests(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    descriptor = json.loads((DPATH_TEST_DATA / "descriptor-valid.json").read_text())
+    descriptor["tool-doi"] = "example/zenodo.1234"
+    fpath_descriptor = tmp_path / "descriptor.json"
+    fpath_descriptor.write_text(json.dumps(descriptor))
+    monkeypatch.setitem(sys.modules, "requests", None)
+    monkeypatch.delitem(sys.modules, "boutiques.puller", raising=False)
+
+    assert isinstance(_check_descriptor_file(fpath_descriptor), str)
 
 
 def test_check_descriptor_file_deprecation_warning(caplog: pytest.LogCaptureFixture):


### PR DESCRIPTION
- Closes #1048

## Changes

Validate the already-loaded descriptor dictionary directly. This prevents Boutiques from mistaking an embedded Zenodo `tool-doi` for a remote record ID and requiring its optional `requests` dependency.

Adds a regression test covering descriptor validation with `requests` unavailable.

## Checklist
_This section is for the PR reviewer_

### All PRs
- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [ ] Checks pass

### If new feature
- [ ] Tests have been added

### If bug fix
- [x] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--1070.org.readthedocs.build/en/1070/

<!-- readthedocs-preview nipoppy end -->