### PR TITLE
[ENH] Add pipeline info command

### DIFF
--- a/nipoppy/cli/options.py
+++ b/nipoppy/cli/options.py
@@ -72,6 +72,26 @@ def layout_option(func):
     return func
 
 
+def pipeline_identifier_options(func):
+    """Define options that identify an installed pipeline."""
+    func = click.option(
+        "--pipeline-version",
+        type=str,
+        help=(
+            "Pipeline version, as specified in the pipeline config file "
+            "(default: latest out of the installed versions)."
+        ),
+    )(func)
+    func = click.option(
+        "--pipeline",
+        "pipeline_name",
+        type=str,
+        required=True,
+        help="Pipeline name, as specified in the config file.",
+    )(func)
+    return func
+
+
 def pipeline_options(func):
     """Define pipeline options for the CLI."""
     func = click.option(
@@ -92,22 +112,7 @@ def pipeline_options(func):
             "(default: first step)."
         ),
     )(func)
-    func = click.option(
-        "--pipeline-version",
-        type=str,
-        help=(
-            "Pipeline version, as specified in the pipeline config file "
-            "(default: latest out of the installed versions)."
-        ),
-    )(func)
-    func = click.option(
-        "--pipeline",
-        "pipeline_name",
-        type=str,
-        required=True,
-        help="Pipeline name, as specified in the config file.",
-    )(func)
-    return func
+    return pipeline_identifier_options(func)
 
 
 def runners_options(func):

--- a/nipoppy/cli/pipeline_catalog.py
+++ b/nipoppy/cli/pipeline_catalog.py
@@ -13,6 +13,7 @@ from nipoppy.cli.options import (
     global_options,
     layout_option,
     password_file_option,
+    pipeline_identifier_options,
 )
 from nipoppy.env import PipelineTypeEnum
 from nipoppy.zenodo_api import ZenodoAPI
@@ -155,6 +156,20 @@ def pipeline_list(**params):
 
     params = dep_params(**params)
     with exception_handler(PipelineListWorkflow(**params)) as workflow:
+        workflow.run()
+
+
+@pipeline.command("info")
+@dataset_option
+@pipeline_identifier_options
+@global_options
+@layout_option
+def pipeline_info(**params):
+    """Show details about an installed pipeline."""
+    from nipoppy.workflows.pipeline_store.info import PipelineInfoWorkflow
+
+    params = dep_params(**params)
+    with exception_handler(PipelineInfoWorkflow(**params)) as workflow:
         workflow.run()
 
 

--- a/nipoppy/workflows/pipeline_store/info.py
+++ b/nipoppy/workflows/pipeline_store/info.py
@@ -1,0 +1,121 @@
+"""Workflow for the pipeline info command."""
+
+from pathlib import Path
+from typing import Optional
+
+from packaging.version import Version
+
+from nipoppy.config.pipeline import BasePipelineConfig
+from nipoppy.env import PipelineTypeEnum, StrOrPathLike
+from nipoppy.exceptions import WorkflowError
+from nipoppy.layout import DatasetLayout
+from nipoppy.logger import emphasize, get_logger
+from nipoppy.pipeline_validation import _load_pipeline_config_file
+from nipoppy.workflows.base import BaseDatasetWorkflow
+
+logger = get_logger()
+
+
+class PipelineInfoWorkflow(BaseDatasetWorkflow):
+    """Show details about a pipeline installed in a dataset."""
+
+    def __init__(
+        self,
+        dpath_root: StrOrPathLike,
+        pipeline_name: str,
+        pipeline_version: Optional[str] = None,
+        fpath_layout: Optional[StrOrPathLike] = None,
+        verbose: bool = False,
+        dry_run: bool = False,
+    ):
+        self.pipeline_name = pipeline_name
+        self.pipeline_version = pipeline_version
+
+        super().__init__(
+            dpath_root,
+            name="pipeline_info",
+            fpath_layout=fpath_layout,
+            verbose=verbose,
+            dry_run=dry_run,
+            _skip_logfile=True,
+        )
+
+    def _find_pipeline(
+        self,
+    ) -> tuple[Path, PipelineTypeEnum, BasePipelineConfig]:
+        """Find the requested pipeline bundle and load its configuration."""
+        matches = []
+        installed = []
+
+        for pipeline_type in PipelineTypeEnum:
+            dpath_store = self.study.layout.get_dpath_pipeline_store(pipeline_type)
+            for fpath_config in sorted(
+                dpath_store.glob(f"*/{DatasetLayout.fname_pipeline_config}")
+            ):
+                config = _load_pipeline_config_file(fpath_config)
+                installed.append(f"{config.NAME} {config.VERSION}")
+
+                if config.NAME != self.pipeline_name:
+                    continue
+                if (
+                    self.pipeline_version is not None
+                    and config.VERSION != self.pipeline_version
+                ):
+                    continue
+
+                matches.append((fpath_config.parent, pipeline_type, config))
+
+        if len(matches) == 0:
+            requested = self.pipeline_name
+            if self.pipeline_version is not None:
+                requested += f" {self.pipeline_version}"
+            available = ", ".join(installed) or "none"
+            raise WorkflowError(
+                f"No installed pipeline found for {requested}. "
+                f"Installed pipelines: {available}"
+            )
+
+        if self.pipeline_version is None:
+            latest_version = max(Version(match[2].VERSION) for match in matches)
+            matches = [
+                match
+                for match in matches
+                if Version(match[2].VERSION) == latest_version
+            ]
+
+        if len(matches) > 1:
+            locations = ", ".join(str(match[0]) for match in matches)
+            raise WorkflowError(
+                f"Multiple installed bundles match {self.pipeline_name}"
+                f" {matches[0][2].VERSION}: {locations}"
+            )
+
+        return matches[0]
+
+    def _log_step(self, dpath_bundle: Path, index: int, step) -> None:
+        """Log details about a pipeline step."""
+        logger.info(emphasize(f"Step {index}: {step.NAME}"))
+        logger.info(f"\tAnalysis level: {step.ANALYSIS_LEVEL.value}")
+
+        for label, field in (
+            ("Descriptor", "DESCRIPTOR_FILE"),
+            ("Invocation", "INVOCATION_FILE"),
+            ("HPC config", "HPC_CONFIG_FILE"),
+            ("Tracker config", "TRACKER_CONFIG_FILE"),
+            ("PyBIDS ignore file", "PYBIDS_IGNORE_FILE"),
+        ):
+            if (relative_path := getattr(step, field, None)) is not None:
+                logger.info(f"\t{label}: {dpath_bundle / relative_path}")
+
+    def run_main(self):
+        """Show details about the requested pipeline."""
+        dpath_bundle, pipeline_type, config = self._find_pipeline()
+
+        logger.info(emphasize(f"{config.NAME} {config.VERSION}"))
+        logger.info(f"Bundle: {dpath_bundle}")
+        logger.info(f"Type: {pipeline_type.value}")
+        logger.info(f"Description: {config.DESCRIPTION or 'None'}")
+        logger.info(f"Steps: {len(config.STEPS)}")
+
+        for index, step in enumerate(config.STEPS, start=1):
+            self._log_step(dpath_bundle, index, step)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -53,6 +53,10 @@ COMMAND_WORKFLOW_MAP = {
         "nipoppy.workflows.pipeline_store.list",
         "PipelineListWorkflow",
     ),
+    "pipeline info": (
+        "nipoppy.workflows.pipeline_store.info",
+        "PipelineInfoWorkflow",
+    ),
     "pipeline validate": (
         "nipoppy.workflows.pipeline_store.validate",
         "PipelineValidateWorkflow",

--- a/tests/unit/workflows/pipeline_store/test_info.py
+++ b/tests/unit/workflows/pipeline_store/test_info.py
@@ -1,0 +1,103 @@
+"""Tests for PipelineInfoWorkflow."""
+
+from pathlib import Path
+
+import pytest
+
+from nipoppy.env import PipelineTypeEnum
+from nipoppy.exceptions import WorkflowError
+from nipoppy.layout import DatasetLayout
+from nipoppy.workflows.pipeline_store.info import PipelineInfoWorkflow
+from tests.conftest import create_empty_dataset, create_pipeline_config_files
+
+
+def _pipeline_config(version: str) -> dict:
+    return {
+        "NAME": "example",
+        "VERSION": version,
+        "DESCRIPTION": "An example processing pipeline",
+        "STEPS": [
+            {
+                "NAME": "preprocess",
+                "ANALYSIS_LEVEL": "participant",
+                "DESCRIPTOR_FILE": "descriptor.json",
+                "INVOCATION_FILE": "invocation.json",
+                "TRACKER_CONFIG_FILE": "tracker.json",
+            }
+        ],
+    }
+
+
+@pytest.fixture()
+def dpath_root(tmp_path: Path) -> Path:
+    dpath_root = tmp_path / "my_dataset"
+    create_empty_dataset(dpath_root)
+    create_pipeline_config_files(
+        DatasetLayout(dpath_root).dpath_pipelines,
+        processing_pipelines=[
+            _pipeline_config("1.0.0"),
+            _pipeline_config("2.0.0"),
+        ],
+    )
+    return dpath_root
+
+
+@pytest.mark.no_xdist
+def test_run_main_uses_latest_version(
+    dpath_root: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    workflow = PipelineInfoWorkflow(dpath_root, pipeline_name="example")
+
+    workflow.run_main()
+
+    output = "\n".join(record.message for record in caplog.records)
+    expected_bundle = (
+        workflow.study.layout.dpath_pipelines
+        / DatasetLayout.pipeline_type_to_dname_map[PipelineTypeEnum.PROCESSING]
+        / "example-2.0.0"
+    )
+    assert "example 2.0.0" in output
+    assert f"Bundle: {expected_bundle}" in output
+    assert "Type: processing" in output
+    assert "Description: An example processing pipeline" in output
+    assert "Steps: 1" in output
+    assert "Step 1: preprocess" in output
+    assert "Analysis level: participant" in output
+    assert f"Descriptor: {expected_bundle / 'descriptor.json'}" in output
+    assert f"Invocation: {expected_bundle / 'invocation.json'}" in output
+    assert f"Tracker config: {expected_bundle / 'tracker.json'}" in output
+
+
+@pytest.mark.no_xdist
+def test_run_main_uses_requested_version(
+    dpath_root: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    workflow = PipelineInfoWorkflow(
+        dpath_root,
+        pipeline_name="example",
+        pipeline_version="1.0.0",
+    )
+
+    workflow.run_main()
+
+    output = "\n".join(record.message for record in caplog.records)
+    assert "example 1.0.0" in output
+    assert "example-1.0.0" in output
+
+
+@pytest.mark.parametrize("pipeline_version", [None, "3.0.0"])
+def test_run_main_pipeline_not_found(
+    dpath_root: Path,
+    pipeline_version: str | None,
+):
+    pipeline_name = "missing" if pipeline_version is None else "example"
+    workflow = PipelineInfoWorkflow(
+        dpath_root,
+        pipeline_name=pipeline_name,
+        pipeline_version=pipeline_version,
+    )
+
+    with pytest.raises(WorkflowError, match="No installed pipeline found"):
+        workflow.run_main()


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->

<!-- Add issue number -->
- Closes #222
<!-- - Related to # -->

<!-- Summarize proposed changes below -->
## Changes

- Add a `nipoppy pipeline info` command for inspecting an installed pipeline bundle.
- Show the bundle path, pipeline type, version, description, and per-step file metadata.
- Use the requested version when supplied, or resolve the latest installed semantic version.
- Add workflow coverage for version selection, output details, and missing pipelines, plus CLI contract coverage.

### AI assistance

OpenAI Codex assisted with the implementation

<!-- DO NOT EDIT OR REMOVE -->
## Checklist
_This section is for the PR reviewer_

### All PRs
- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

### If new feature
- [ ] Tests have been added

### If bug fix
- [ ] There is at least one test that would fail under the original bug conditions

<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--1079.org.readthedocs.build/en/1079/

<!-- readthedocs-preview nipoppy end -->