### PR TITLE
[MAINT] Fix release workflow artifact upload

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -74,13 +74,3 @@ jobs:
         inputs: >-
           ./dist/*.tar.gz
           ./dist/*.whl
-    - name: Upload artifact signatures to GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-      # Upload to GitHub Release using the `gh` CLI.
-      # `dist/` contains the built packages, and the
-      # sigstore-produced signatures and certificates.
-      run: >-
-        gh release upload
-        '${{ github.ref_name }}' dist/**
-        --repo '${{ github.repository }}'

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
-    - name: Sign the dists with Sigstore
+    - name: Sign and upload the dists with Sigstore
       uses: sigstore/gh-action-sigstore-python@v3.5.0
       with:
         inputs: >-

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -5,6 +5,7 @@ name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -5,7 +5,6 @@ name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 on:
   release:
     types: [published]
-  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -57,12 +57,6 @@ jobs:
       contents: write  # IMPORTANT: mandatory for updating GitHub Releases
       id-token: write  # IMPORTANT: mandatory for sigstore
     steps:
-    - name: Generate a token
-      id: generate-token
-      uses: actions/create-github-app-token@v3
-      with:
-        app-id: ${{ vars.NIPOPPY_BOT_APP_ID }}
-        private-key: ${{ secrets.NIPOPPY_BOT_PRIVATE_KEY }}
     - name: Download all the dists
       uses: actions/download-artifact@v8
       with:


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->

<!-- Add issue number -->
- Closes #962
<!-- - Related to # -->

<!-- Summarize proposed changes below -->
## Changes
- #833 changed the workflow trigger to be on release rather than on tag push. Because of this, Sigstore will directly upload the Python package build files to the release, so we don't need the last `gh release upload` step anymore
- I also figured out why we are getting all these new files added to the release: Sigstore will re-sign and upload the default source code archives, see https://github.com/sigstore/gh-action-sigstore-python#release-signing-artifacts

<!-- DO NOT EDIT OR REMOVE -->
## Checklist
_This section is for the PR reviewer_

### All PRs
- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

### If new feature
- [ ] Tests have been added

### If bug fix
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--1094.org.readthedocs.build/en/1094/

<!-- readthedocs-preview nipoppy end -->