### PR TITLE
[MAINT] Make `nipoppy track-curation` always regenerate the curation status file

### DIFF
--- a/docs/source/how_to_guides/reorganize_sourcedata/index.md
+++ b/docs/source/how_to_guides/reorganize_sourcedata/index.md
@@ -109,7 +109,7 @@ sub- and ses- prefix added
 $ nipoppy status --dataset <NIPOPPY_PROJECT_ROOT>
 ```
 
-The output should list the number of participants that are present in both the {term}`manifest file` and in {{dpath_pre_reorg}} but are not in {{dpath_post_reorg}} yet, according to the {term}`curation status file`. These are the participants and session Nipoppy will loop over when running `nipoppy reorg`. If you feel like the information of `nipoppy status` is outdated, you can run `nipoppy track-curation --regenerate` to update.
+The output should list the number of participants that are present in both the {term}`manifest file` and in {{dpath_pre_reorg}} but are not in {{dpath_post_reorg}} yet, according to the {term}`curation status file`. These are the participants and session Nipoppy will loop over when running `nipoppy reorg`. If you feel like the information of `nipoppy status` is outdated, you can run `nipoppy track-curation` to update.
 
 - file organization in {{dpath_pre_reorg}} must follow a subject-first, session-second manner (see next section for help if this is not the case for your data)
 - the {term}`manifest file` must list all participants and sessions

--- a/docs/source/how_to_guides/tracking/index.md
+++ b/docs/source/how_to_guides/tracking/index.md
@@ -8,11 +8,7 @@ The [`nipoppy track-curation`](../../reference/cli_reference/track_curation.rst)
 The command to create a curation status file from scratch is:
 
 ```console
-$ nipoppy track-curation --regenerate
-```
-
-```{note}
-Without the `--regenerate` flag, `nipoppy track-curation` will only update the curation status for new participants in the {term}`manifest <manifest file>`.
+$ nipoppy track-curation
 ```
 
 The above command creates or updates the curation status file at {{fpath_curation_status}}.

--- a/docs/source/overview/quickstart/index.md
+++ b/docs/source/overview/quickstart/index.md
@@ -161,7 +161,7 @@ $ nipoppy bidsify --pipeline dcm2bids --pipeline-step convert
 
 **3.** Track the curation status:
 ```{code-block} console
-$ nipoppy track-curation --regenerate
+$ nipoppy track-curation
 ```
 
 The curation status file can be found at {{fpath_curation_status}}.

--- a/docs/source/tutorials/videos/index.md
+++ b/docs/source/tutorials/videos/index.md
@@ -17,7 +17,7 @@ In this tutorial we will cover how to create a new Nipoppy dataset. More concret
 - discover the directories that follow the Nipoppy specification
 - explore the [`nipoppy status`](../../reference/cli_reference/status.rst) command
 - modify the content of the [`manifest.tsv`](../../explanations/manifest.md) file according to our dataset
-- and run the [`nipoppy track-curation --regenerate`](../../reference/cli_reference/track_curation.rst) command
+- and run the [`nipoppy track-curation`](../../reference/cli_reference/track_curation.rst) command
 
 Duration: 7:43m
 

--- a/nipoppy/cli/cli.py
+++ b/nipoppy/cli/cli.py
@@ -45,7 +45,6 @@ click.rich_click.OPTION_GROUPS = {
                 "--mode",
                 "--container-store",
                 "--default-config",
-                "--empty",
                 "--copy-files",
                 "--check-dicoms",
                 "--tar",
@@ -55,6 +54,7 @@ click.rich_click.OPTION_GROUPS = {
                 "--password-file",
                 "--sandbox",
                 "--community",
+                "--regenerate",
             ],
         },
         {
@@ -107,7 +107,6 @@ click.rich_click.OPTION_GROUPS = {
 @click.version_option(version=__version__)
 def cli():
     """Organize and process neuroimaging-clinical datasets."""
-    pass
 
 
 if cli.commands.get("gui"):
@@ -164,21 +163,12 @@ def init(**params):
 @cli.command()
 @dataset_option
 @click.option(
-    "--empty",
-    is_flag=True,
-    help=(
-        "Set all statuses to False in newly added records"
-        " (regardless of what is on disk). May be useful to reduce runtime."
-    ),
-)
-@click.option(
-    "--force",
     "--regenerate",
-    "-f",
     is_flag=True,
-    help=(
-        "Regenerate the curation status file even if it already exists"
-        " (default: only append rows for new records)"
+    help="Regenerate the curation status file even if it already exists.",
+    deprecated=(
+        "This is now the default/only behaviour,"
+        " and this option will be removed in a future release."
     ),
 )
 @global_options

--- a/nipoppy/tabular/curation_status.py
+++ b/nipoppy/tabular/curation_status.py
@@ -153,7 +153,6 @@ def generate_curation_status_table(
     dpath_downloaded: StrOrPathLike | None = None,
     dpath_organized: StrOrPathLike | None = None,
     dpath_bidsified: StrOrPathLike | None = None,
-    empty=False,
 ) -> CurationStatusTable:
     """Generate a curation status table."""
 
@@ -193,29 +192,24 @@ def generate_curation_status_table(
         bids_participant_id = participant_id_to_bids_participant_id(participant_id)
         bids_session_id = session_id_to_bids_session_id(session_id)
 
-        if empty:
-            status_downloaded = False
-            status_organized = False
-            status_bidsified = False
+        status_downloaded = check_status(
+            dpath=dpath_downloaded,
+            dname_subdirectory=participant_dicom_dir,
+        )
+        status_organized = check_status(
+            dpath=dpath_organized,
+            dname_subdirectory=Path(bids_participant_id, bids_session_id),
+        )
+        if session_id == FAKE_SESSION_ID:
+            # if the session is fake, we don't expect BIDS data
+            # to have bids_session_id in the path
+            dname_subdirectory = Path(bids_participant_id)
         else:
-            status_downloaded = check_status(
-                dpath=dpath_downloaded,
-                dname_subdirectory=participant_dicom_dir,
-            )
-            status_organized = check_status(
-                dpath=dpath_organized,
-                dname_subdirectory=Path(bids_participant_id, bids_session_id),
-            )
-            if session_id == FAKE_SESSION_ID:
-                # if the session is fake, we don't expect BIDS data
-                # to have bids_session_id in the path
-                dname_subdirectory = Path(bids_participant_id)
-            else:
-                dname_subdirectory = Path(bids_participant_id, bids_session_id)
-            status_bidsified = check_status(
-                dpath=dpath_bidsified,
-                dname_subdirectory=dname_subdirectory,
-            )
+            dname_subdirectory = Path(bids_participant_id, bids_session_id)
+        status_bidsified = check_status(
+            dpath=dpath_bidsified,
+            dname_subdirectory=dname_subdirectory,
+        )
 
         curation_status_records.append(
             {
@@ -246,7 +240,6 @@ def update_curation_status_table(
     dpath_downloaded: StrOrPathLike | None = None,
     dpath_organized: StrOrPathLike | None = None,
     dpath_bidsified: StrOrPathLike | None = None,
-    empty=False,
 ) -> CurationStatusTable:
     """Update an existing curation status file."""
     logger.debug(f"Original curation status table:\n{curation_status_table}")
@@ -266,7 +259,6 @@ def update_curation_status_table(
             dpath_downloaded=dpath_downloaded,
             dpath_organized=dpath_organized,
             dpath_bidsified=dpath_bidsified,
-            empty=empty,
         )
     )
 

--- a/nipoppy/workflows/base.py
+++ b/nipoppy/workflows/base.py
@@ -301,7 +301,6 @@ class BaseDatasetWorkflow(BaseWorkflow, ABC):
                 dpath_downloaded=self.study.layout.dpath_pre_reorg,
                 dpath_organized=self.study.layout.dpath_post_reorg,
                 dpath_bidsified=self.study.layout.dpath_bids,
-                empty=False,
             )
 
             if not self.dry_run:

--- a/nipoppy/workflows/track_curation.py
+++ b/nipoppy/workflows/track_curation.py
@@ -4,11 +4,7 @@ from pathlib import Path
 
 from nipoppy.env import StrOrPathLike
 from nipoppy.logger import get_logger
-from nipoppy.tabular.curation_status import (
-    CurationStatusTable,
-    generate_curation_status_table,
-    update_curation_status_table,
-)
+from nipoppy.tabular.curation_status import generate_curation_status_table
 from nipoppy.workflows.base import BaseDatasetWorkflow
 
 logger = get_logger()
@@ -20,10 +16,10 @@ class TrackCurationWorkflow(BaseDatasetWorkflow):
     def __init__(
         self,
         dpath_root: Path,
-        force: bool = False,
         fpath_layout: StrOrPathLike | None = None,
         verbose: bool = False,
         dry_run: bool = False,
+        regenerate: bool | None = None,  # deprecated
     ):
         """Initialize the workflow."""
         super().__init__(
@@ -34,8 +30,6 @@ class TrackCurationWorkflow(BaseDatasetWorkflow):
             dry_run=dry_run,
         )
 
-        self.force = force
-
     def run_main(self):
         """Generate/update the dataset's curation status file."""
         fpath_table = self.study.layout.fpath_curation_status
@@ -43,36 +37,15 @@ class TrackCurationWorkflow(BaseDatasetWorkflow):
         dpath_organized = self.study.layout.dpath_post_reorg
         dpath_bidsified = self.study.layout.dpath_bids
 
-        if fpath_table.exists() and not self.force:
-            old_table = CurationStatusTable.load(fpath_table)
-            logger.info(
-                f"Found existing curation status file (shape: {old_table.shape})"
-            )
-            table = update_curation_status_table(
-                curation_status_table=old_table,
-                manifest=self.study.manifest,
-                dicom_dir_map=self.dicom_dir_map,
-                dpath_downloaded=dpath_downloaded,
-                dpath_organized=dpath_organized,
-                dpath_bidsified=dpath_bidsified,
-            )
+        table = generate_curation_status_table(
+            manifest=self.study.manifest,
+            dicom_dir_map=self.dicom_dir_map,
+            dpath_downloaded=dpath_downloaded,
+            dpath_organized=dpath_organized,
+            dpath_bidsified=dpath_bidsified,
+        )
 
-        else:
-            if self.force:
-                logger.info("Regenerating the entire curation status file")
-            else:
-                logger.info(
-                    f"Did not find existing curation status file at {fpath_table}"
-                )
-            table = generate_curation_status_table(
-                manifest=self.study.manifest,
-                dicom_dir_map=self.dicom_dir_map,
-                dpath_downloaded=dpath_downloaded,
-                dpath_organized=dpath_organized,
-                dpath_bidsified=dpath_bidsified,
-            )
-
-        logger.info(f"New/updated curation status table shape: {table.shape}")
+        logger.info(f"Curation status table shape: {table.shape}")
         table.save_with_backup(fpath_table, dry_run=self.dry_run)
 
         logger.success(

--- a/nipoppy/workflows/track_curation.py
+++ b/nipoppy/workflows/track_curation.py
@@ -20,7 +20,6 @@ class TrackCurationWorkflow(BaseDatasetWorkflow):
     def __init__(
         self,
         dpath_root: Path,
-        empty: bool = False,
         force: bool = False,
         fpath_layout: StrOrPathLike | None = None,
         verbose: bool = False,
@@ -35,7 +34,6 @@ class TrackCurationWorkflow(BaseDatasetWorkflow):
             dry_run=dry_run,
         )
 
-        self.empty = empty
         self.force = force
 
     def run_main(self):
@@ -44,7 +42,6 @@ class TrackCurationWorkflow(BaseDatasetWorkflow):
         dpath_downloaded = self.study.layout.dpath_pre_reorg
         dpath_organized = self.study.layout.dpath_post_reorg
         dpath_bidsified = self.study.layout.dpath_bids
-        empty = self.empty
 
         if fpath_table.exists() and not self.force:
             old_table = CurationStatusTable.load(fpath_table)
@@ -58,7 +55,6 @@ class TrackCurationWorkflow(BaseDatasetWorkflow):
                 dpath_downloaded=dpath_downloaded,
                 dpath_organized=dpath_organized,
                 dpath_bidsified=dpath_bidsified,
-                empty=empty,
             )
 
         else:
@@ -74,7 +70,6 @@ class TrackCurationWorkflow(BaseDatasetWorkflow):
                 dpath_downloaded=dpath_downloaded,
                 dpath_organized=dpath_organized,
                 dpath_bidsified=dpath_bidsified,
-                empty=empty,
             )
 
         logger.info(f"New/updated curation status table shape: {table.shape}")

--- a/nipoppy/workflows/track_curation.py
+++ b/nipoppy/workflows/track_curation.py
@@ -29,6 +29,7 @@ class TrackCurationWorkflow(BaseDatasetWorkflow):
             verbose=verbose,
             dry_run=dry_run,
         )
+        self.regenerate = regenerate  # not used but needed for __repr__ to work
 
     def run_main(self):
         """Generate/update the dataset's curation status file."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -420,37 +420,28 @@ def check_curation_status_table(
     participants_and_sessions_downloaded,
     participants_and_sessions_organized,
     participants_and_sessions_bidsified,
-    empty,
 ):
     """Check that a curation status table has the corrected status values."""
-    if empty:
-        for col in [
-            table.col_in_pre_reorg,
-            table.col_in_post_reorg,
-            table.col_in_bids,
-        ]:
-            assert (~table[col]).all()
-    else:
-        for participant_id in participants_and_sessions_manifest:
-            for session_id in participants_and_sessions_manifest[participant_id]:
-                for col, participants_and_sessions_true in {
-                    table.col_in_pre_reorg: participants_and_sessions_downloaded,
-                    table.col_in_post_reorg: participants_and_sessions_organized,
-                    table.col_in_bids: participants_and_sessions_bidsified,
-                }.items():
-                    status: pd.Series = table.loc[
-                        (table[table.col_participant_id] == participant_id)
-                        & (table[table.col_session_id] == session_id),
-                        col,
-                    ]
+    for participant_id in participants_and_sessions_manifest:
+        for session_id in participants_and_sessions_manifest[participant_id]:
+            for col, participants_and_sessions_true in {
+                table.col_in_pre_reorg: participants_and_sessions_downloaded,
+                table.col_in_post_reorg: participants_and_sessions_organized,
+                table.col_in_bids: participants_and_sessions_bidsified,
+            }.items():
+                status: pd.Series = table.loc[
+                    (table[table.col_participant_id] == participant_id)
+                    & (table[table.col_session_id] == session_id),
+                    col,
+                ]
 
-                    assert len(status) == 1
-                    status = status.iloc[0]
+                assert len(status) == 1
+                status = status.iloc[0]
 
-                    assert status == (
-                        participant_id in participants_and_sessions_true
-                        and session_id in participants_and_sessions_true[participant_id]
-                    )
+                assert status == (
+                    participant_id in participants_and_sessions_true
+                    and session_id in participants_and_sessions_true[participant_id]
+                )
 
 
 @pytest.fixture

--- a/tests/unit/tabular/test_curation_status.py
+++ b/tests/unit/tabular/test_curation_status.py
@@ -197,7 +197,6 @@ def test_get_participant_sessions_helper(
         ),
     ],
 )
-@pytest.mark.parametrize("empty", [True, False])
 @pytest.mark.parametrize("str_paths", [False, True])
 def test_generate_and_update(
     participants_and_sessions_manifest1: dict[str, list[str]],
@@ -208,7 +207,6 @@ def test_generate_and_update(
     dpath_downloaded_relative: StrOrPathLike,
     dpath_organized_relative: StrOrPathLike,
     dpath_bidsified_relative: StrOrPathLike,
-    empty: bool,
     str_paths: bool,
     tmp_path: Path,
 ):
@@ -242,7 +240,6 @@ def test_generate_and_update(
         dpath_downloaded=dpath_downloaded,
         dpath_organized=dpath_organized,
         dpath_bidsified=dpath_bidsified,
-        empty=empty,
     )
     # the table should have the same number of records as the manifest
     assert len(table1) == len(manifest1)
@@ -253,7 +250,6 @@ def test_generate_and_update(
         participants_and_sessions_downloaded=participants_and_sessions_downloaded,
         participants_and_sessions_organized=participants_and_sessions_organized,
         participants_and_sessions_bidsified=participants_and_sessions_bidsified,
-        empty=empty,
     )
 
     # create a new manifest
@@ -267,7 +263,6 @@ def test_generate_and_update(
         dpath_downloaded=dpath_downloaded,
         dpath_organized=dpath_organized,
         dpath_bidsified=dpath_bidsified,
-        empty=empty,
     )
     assert len(table2) == len(manifest2)
 
@@ -277,7 +272,6 @@ def test_generate_and_update(
         participants_and_sessions_downloaded=participants_and_sessions_downloaded,
         participants_and_sessions_organized=participants_and_sessions_organized,
         participants_and_sessions_bidsified=participants_and_sessions_bidsified,
-        empty=empty,
     )
 
 
@@ -310,7 +304,6 @@ def test_generate_missing_paths(tmp_path: Path):
         dpath_downloaded=dpath_downloaded,
         dpath_organized=dpath_organized,
         dpath_bidsified=dpath_bidsified,
-        empty=False,
     )
 
     assert table[CurationStatusTable.col_in_pre_reorg].all()
@@ -355,7 +348,6 @@ def test_curation_status_table_generation_no_session(
         dpath_downloaded=None,
         dpath_organized=None,
         dpath_bidsified=dpath_bidsified,
-        empty=False,
     )
 
     assert table[CurationStatusTable.col_participant_id].to_list() == ["01", "02"]

--- a/tests/unit/workflows/test_track_curation.py
+++ b/tests/unit/workflows/test_track_curation.py
@@ -44,7 +44,6 @@ def test_run_main_without_existing_curation_status_file(
 
     workflow.run_main()
 
-    assert "Did not find existing curation status file at" in caplog.text
     mocked_generate_curation_status_table.assert_called_once_with(
         manifest=workflow.study.manifest,
         dicom_dir_map=workflow.dicom_dir_map,
@@ -59,4 +58,46 @@ def test_run_main_without_existing_curation_status_file(
     assert (
         "Successfully generated/updated the dataset's curation status file"
         in caplog.text
+    )
+
+
+def test_run_main_overwrites_existing_curation_status_file(
+    workflow: TrackCurationWorkflow,
+    mocker: pytest_mock.MockerFixture,
+):
+    old_curation_status_table = CurationStatusTable().add_or_update_records(
+        [
+            {
+                CurationStatusTable.col_participant_id: "01",
+                CurationStatusTable.col_visit_id: "BL",
+                CurationStatusTable.col_session_id: "BL",
+                CurationStatusTable.col_datatype: ["anat"],
+                CurationStatusTable.col_participant_dicom_dir: "01/BL",
+                CurationStatusTable.col_in_pre_reorg: True,
+                CurationStatusTable.col_in_post_reorg: True,
+                CurationStatusTable.col_in_bids: True,
+            },
+        ]
+    )
+    old_curation_status_table.save_with_backup(
+        workflow.study.layout.fpath_curation_status
+    )
+
+    new_curation_status_table = CurationStatusTable()
+    mocked_generate_curation_status_table = mocker.patch(
+        "nipoppy.workflows.track_curation.generate_curation_status_table",
+        return_value=new_curation_status_table,
+    )
+
+    workflow.run_main()
+
+    mocked_generate_curation_status_table.assert_called_once_with(
+        manifest=workflow.study.manifest,
+        dicom_dir_map=workflow.dicom_dir_map,
+        dpath_downloaded=workflow.study.layout.dpath_pre_reorg,
+        dpath_organized=workflow.study.layout.dpath_post_reorg,
+        dpath_bidsified=workflow.study.layout.dpath_bids,
+    )
+    assert CurationStatusTable.load(workflow.study.layout.fpath_curation_status).equals(
+        new_curation_status_table
     )

--- a/tests/unit/workflows/test_track_curation.py
+++ b/tests/unit/workflows/test_track_curation.py
@@ -25,7 +25,7 @@ def workflow(tmp_path: Path):
     return workflow
 
 
-def test_run_main_without_existing_curation_status_file(
+def test_run_without_existing_curation_status_file(
     workflow: TrackCurationWorkflow,
     mocker: pytest_mock.MockerFixture,
     caplog: pytest.LogCaptureFixture,
@@ -42,7 +42,7 @@ def test_run_main_without_existing_curation_status_file(
         curation_status_table, "save_with_backup"
     )
 
-    workflow.run_main()
+    workflow.run()
 
     mocked_generate_curation_status_table.assert_called_once_with(
         manifest=workflow.study.manifest,
@@ -61,7 +61,7 @@ def test_run_main_without_existing_curation_status_file(
     )
 
 
-def test_run_main_overwrites_existing_curation_status_file(
+def test_run_overwrites_existing_curation_status_file(
     workflow: TrackCurationWorkflow,
     mocker: pytest_mock.MockerFixture,
 ):
@@ -89,7 +89,7 @@ def test_run_main_overwrites_existing_curation_status_file(
         return_value=new_curation_status_table,
     )
 
-    workflow.run_main()
+    workflow.run()
 
     mocked_generate_curation_status_table.assert_called_once_with(
         manifest=workflow.study.manifest,

--- a/tests/unit/workflows/test_track_curation.py
+++ b/tests/unit/workflows/test_track_curation.py
@@ -51,7 +51,6 @@ def test_run_main_without_existing_curation_status_file(
         dpath_downloaded=workflow.study.layout.dpath_pre_reorg,
         dpath_organized=workflow.study.layout.dpath_post_reorg,
         dpath_bidsified=workflow.study.layout.dpath_bids,
-        empty=workflow.empty,
     )
     mocked_save_with_backup.assert_called_once_with(
         workflow.study.layout.fpath_curation_status,

--- a/tests/unit/workflows/test_track_curation.py
+++ b/tests/unit/workflows/test_track_curation.py
@@ -3,16 +3,11 @@
 from pathlib import Path
 
 import pytest
+import pytest_mock
 
 from nipoppy.tabular.curation_status import CurationStatusTable
-from nipoppy.tabular.manifest import Manifest
 from nipoppy.workflows.track_curation import TrackCurationWorkflow
-from tests.conftest import (
-    check_curation_status_table,
-    create_empty_dataset,
-    get_config,
-    prepare_dataset,
-)
+from tests.conftest import create_empty_dataset, get_config, prepare_dataset
 
 
 @pytest.fixture(scope="function")
@@ -22,185 +17,47 @@ def workflow(tmp_path: Path):
     workflow = TrackCurationWorkflow(dpath_root=dpath_root)
     workflow.study.config = get_config()
     workflow.study.config.save(workflow.study.layout.fpath_config)
+
+    manifest = prepare_dataset(
+        participants_and_sessions_manifest={"01": ["BL", "M12"], "02": ["BL", "M12"]},
+    )
+    workflow.study.manifest = manifest
     return workflow
 
 
-@pytest.mark.parametrize(
-    (
-        "participants_and_sessions_manifest1"
-        ",participants_and_sessions_manifest2"
-        ",participants_and_sessions_downloaded"
-        ",participants_and_sessions_organized"
-        ",participants_and_sessions_bidsified"
-    ),
-    [
-        (
-            {"01": ["BL", "M12"], "02": ["BL", "M12"]},
-            {
-                "01": ["BL", "M12"],
-                "02": ["BL", "M12"],
-                "03": ["BL", "M12"],
-            },
-            {"01": ["BL", "M12"], "02": ["BL"]},
-            {"01": ["BL"], "02": ["BL"], "03": ["BL"]},
-            {"01": ["BL", "M12"], "03": ["M12"]},
-        ),
-        (
-            {"PD01": ["BL"], "PD02": ["BL"]},
-            {"PD01": ["BL", "M12"], "PD02": ["BL", "M12"]},
-            {"PD01": ["BL", "M12"], "PD02": ["BL", "M12"]},
-            {"PD01": ["BL"], "PD02": ["BL", "M12"]},
-            {"PD01": ["BL"], "PD02": ["BL"]},
-        ),
-    ],
-)
-@pytest.mark.parametrize("empty", [True, False])
-@pytest.mark.no_xdist
-def test_run_main(
+def test_run_main_without_existing_curation_status_file(
     workflow: TrackCurationWorkflow,
-    participants_and_sessions_manifest1: dict[str, list[str]],
-    participants_and_sessions_manifest2: dict[str, list[str]],
-    participants_and_sessions_downloaded: dict[str, list[str]],
-    participants_and_sessions_organized: dict[str, list[str]],
-    participants_and_sessions_bidsified: dict[str, list[str]],
-    empty: bool,
+    mocker: pytest_mock.MockerFixture,
     caplog: pytest.LogCaptureFixture,
 ):
-    workflow.empty = empty
+    workflow.study.layout.fpath_curation_status.unlink(missing_ok=True)
+    assert not workflow.study.layout.fpath_curation_status.exists()
 
-    # initial manifest
-    manifest1 = prepare_dataset(
-        participants_and_sessions_manifest=participants_and_sessions_manifest1,
-        participants_and_sessions_downloaded=participants_and_sessions_downloaded,
-        participants_and_sessions_organized=participants_and_sessions_organized,
-        participants_and_sessions_bidsified=participants_and_sessions_bidsified,
+    curation_status_table = CurationStatusTable()
+    mocked_generate_curation_status_table = mocker.patch(
+        "nipoppy.workflows.track_curation.generate_curation_status_table",
+        return_value=curation_status_table,
+    )
+    mocked_save_with_backup = mocker.patch.object(
+        curation_status_table, "save_with_backup"
+    )
+
+    workflow.run_main()
+
+    assert "Did not find existing curation status file at" in caplog.text
+    mocked_generate_curation_status_table.assert_called_once_with(
+        manifest=workflow.study.manifest,
+        dicom_dir_map=workflow.dicom_dir_map,
         dpath_downloaded=workflow.study.layout.dpath_pre_reorg,
         dpath_organized=workflow.study.layout.dpath_post_reorg,
         dpath_bidsified=workflow.study.layout.dpath_bids,
+        empty=workflow.empty,
     )
-    workflow.study.manifest = manifest1
-
-    # generate the curation status table
-    workflow.run_main()
-    table1 = CurationStatusTable.load(workflow.study.layout.fpath_curation_status)
-
-    assert len(table1) == len(manifest1)
-    check_curation_status_table(
-        table=table1,
-        participants_and_sessions_manifest=participants_and_sessions_manifest1,
-        participants_and_sessions_downloaded=participants_and_sessions_downloaded,
-        participants_and_sessions_organized=participants_and_sessions_organized,
-        participants_and_sessions_bidsified=participants_and_sessions_bidsified,
-        empty=empty,
+    mocked_save_with_backup.assert_called_once_with(
+        workflow.study.layout.fpath_curation_status,
+        dry_run=workflow.dry_run,
     )
-
-    # update the manifest (add rows)
-    manifest2 = prepare_dataset(participants_and_sessions_manifest2)
-    manifest2.save_with_backup(workflow.study.layout.fpath_manifest)
-
-    # update the curation status table
-    TrackCurationWorkflow(dpath_root=workflow.dpath_root, empty=empty).run()
-    table2 = CurationStatusTable.load(workflow.study.layout.fpath_curation_status)
-
-    assert len(table2) == len(manifest2)
-    check_curation_status_table(
-        table=table2,
-        participants_and_sessions_manifest=participants_and_sessions_manifest2,
-        participants_and_sessions_downloaded=participants_and_sessions_downloaded,
-        participants_and_sessions_organized=participants_and_sessions_organized,
-        participants_and_sessions_bidsified=participants_and_sessions_bidsified,
-        empty=empty,
-    )
-
     assert (
         "Successfully generated/updated the dataset's curation status file"
         in caplog.text
-    )
-
-
-@pytest.mark.parametrize(
-    (
-        "participants_and_sessions_manifest"
-        ",participants_and_sessions_downloaded"
-        ",participants_and_sessions_organized"
-        ",participants_and_sessions_bidsified"
-    ),
-    [
-        (
-            {"01": ["BL", "M12"], "02": ["BL", "M12"]},
-            {"01": ["BL", "M12"], "02": ["BL"]},
-            {"01": ["BL"], "02": ["BL"], "03": ["BL"]},
-            {"01": ["BL", "M12"], "03": ["M12"]},
-        ),
-        (
-            {"PD01": ["BL", "M12"], "PD02": ["BL"]},
-            {"PD01": ["BL", "M12"], "PD02": ["BL", "M12"]},
-            {"PD01": ["BL"], "PD02": ["BL", "M12"]},
-            {"PD01": ["BL"], "PD02": ["BL"]},
-        ),
-    ],
-)
-@pytest.mark.parametrize("empty", [True, False])
-def test_run_main_regenerate(
-    workflow: TrackCurationWorkflow,
-    participants_and_sessions_manifest: dict[str, list[str]],
-    participants_and_sessions_downloaded: dict[str, list[str]],
-    participants_and_sessions_organized: dict[str, list[str]],
-    participants_and_sessions_bidsified: dict[str, list[str]],
-    empty: bool,
-):
-    workflow.empty = empty
-    workflow.force = True
-
-    manifest = prepare_dataset(
-        participants_and_sessions_manifest=participants_and_sessions_manifest,
-        participants_and_sessions_downloaded=participants_and_sessions_downloaded,
-        participants_and_sessions_organized=participants_and_sessions_organized,
-        participants_and_sessions_bidsified=participants_and_sessions_bidsified,
-        dpath_downloaded=workflow.study.layout.dpath_pre_reorg,
-        dpath_organized=workflow.study.layout.dpath_post_reorg,
-        dpath_bidsified=workflow.study.layout.dpath_bids,
-    )
-    workflow.study.manifest = manifest
-
-    # to be overwritten
-    table_records = []
-    for _, manifest_record in manifest.iterrows():
-        participant_id = manifest_record[Manifest.col_participant_id]
-        table_records.append(
-            {
-                CurationStatusTable.col_participant_id: participant_id,
-                CurationStatusTable.col_visit_id: manifest_record[
-                    Manifest.col_visit_id
-                ],
-                CurationStatusTable.col_session_id: manifest_record[
-                    Manifest.col_session_id
-                ],
-                CurationStatusTable.col_datatype: manifest_record[
-                    Manifest.col_datatype
-                ],
-                CurationStatusTable.col_participant_dicom_dir: participant_id,
-                CurationStatusTable.col_in_pre_reorg: True,
-                CurationStatusTable.col_in_post_reorg: True,
-                CurationStatusTable.col_in_bids: True,
-            }
-        )
-    table_old = CurationStatusTable(table_records)
-    assert (
-        table_old.save_with_backup(workflow.study.layout.fpath_curation_status)
-        is not None
-    )
-
-    # regenerate the table
-    workflow.run_main()
-    table = CurationStatusTable.load(workflow.study.layout.fpath_curation_status)
-
-    assert len(table) == len(manifest)
-    check_curation_status_table(
-        table=table,
-        participants_and_sessions_manifest=participants_and_sessions_manifest,
-        participants_and_sessions_downloaded=participants_and_sessions_downloaded,
-        participants_and_sessions_organized=participants_and_sessions_organized,
-        participants_and_sessions_bidsified=participants_and_sessions_bidsified,
-        empty=empty,
     )


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->

<!-- Add issue number -->
- Closes #401
<!-- - Related to # -->

<!-- Summarize proposed changes below -->
`nipoppy track-curation` does not take that long to run, so it does not cost too much to do the regeneration all the time

## Changes
- Always regenerate
- `--regenerate` is still a valid flag but there is now a deprecation warning. In a future version it will be removed and cause an error
- `--empty` flag is removed as it is also not that useful
- Simplified workflow tests to have more mocking since the underlying table-generation functionality is already tested elsewhere


<!-- DO NOT EDIT OR REMOVE -->
## Checklist
_This section is for the PR reviewer_

### All PRs
- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

### If new feature
- [ ] Tests have been added

### If bug fix
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--1114.org.readthedocs.build/en/1114/

<!-- readthedocs-preview nipoppy end -->