### PR TITLE
[BUG] Error on an empty BIDS manifest

### DIFF
--- a/nipoppy/workflows/dataset_init.py
+++ b/nipoppy/workflows/dataset_init.py
@@ -18,7 +18,7 @@ from nipoppy.env import (
     PipelineTypeEnum,
     StrOrPathLike,
 )
-from nipoppy.exceptions import FileOperationError
+from nipoppy.exceptions import FileOperationError, WorkflowError
 from nipoppy.logger import get_logger
 from nipoppy.tabular.manifest import Manifest
 from nipoppy.utils import fileops
@@ -276,6 +276,12 @@ class InitWorkflow(BaseDatasetWorkflow):
                 if x.is_dir() and x.name.startswith(BIDS_SUBJECT_PREFIX)
             ]
         )
+
+        if not bids_participant_ids:
+            raise WorkflowError(
+                "No BIDS subject directories found in "
+                f"{self.study.layout.dpath_bids}."
+            )
 
         logger.info("Creating a manifest file from the BIDS dataset content.")
 

--- a/tests/unit/workflows/test_init.py
+++ b/tests/unit/workflows/test_init.py
@@ -12,7 +12,7 @@ import pytest_mock
 from fids import fids
 
 from nipoppy.env import FAKE_SESSION_ID
-from nipoppy.exceptions import FileOperationError
+from nipoppy.exceptions import FileOperationError, WorkflowError
 from nipoppy.tabular.manifest import Manifest
 from nipoppy.utils import fileops
 from nipoppy.utils.utils import DPATH_HPC, DPATH_LAYOUTS, FPATH_SAMPLE_CONFIG
@@ -446,6 +446,15 @@ def test_init_bids(
     _assert_manifest_creation(workflow)
     mocked_handle_bids_source.assert_called_once()
     assert "Sample manifest file copied" not in caplog.text
+
+
+def test_init_bids_no_subjects(workflow: InitWorkflow, tmp_path: Path):
+    bids_source = tmp_path / "empty_bids"
+    bids_source.mkdir()
+    workflow.bids_source = bids_source
+
+    with pytest.raises(WorkflowError, match="No BIDS subject directories found"):
+        workflow.run()
 
 
 def test_handle_bids_source_invalid_mode(workflow: InitWorkflow, fake_bids_root: Path):


### PR DESCRIPTION
- Closes #897

## Changes

- Raise a `WorkflowError` when `nipoppy init --bids-source` finds no BIDS subject directories.
- Add a regression test for an empty BIDS source.

## Checklist
_This section is for the PR reviewer_

### All PRs
- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

### If bug fix
- [ ] There is at least one test that would fail under the original bug conditions

<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--1116.org.readthedocs.build/en/1116/

<!-- readthedocs-preview nipoppy end -->