### PR TITLE
[DOC] add note about nipoppy version for tutorials

### DIFF
--- a/docs/source/tutorials/videos/index.md
+++ b/docs/source/tutorials/videos/index.md
@@ -10,8 +10,7 @@ $ git clone https://github.com/nipoppy/tutorial-dataset.git
 
 or visit the [GitHub repo](https://github.com/nipoppy/tutorial-dataset) and download the data without using `git`. We show in the videos how to!
 
-```{note}
-Nipoppy version used in the tutorial videos was 0.4.5. Console output as well as certain flags could have changed between this version and newer versions. Please consult the release notes on [GitHub](https://github.com/nipoppy/nipoppy/releases) for details. E.g., the `--regenerate` flag for the `track-curation` command will be deprecated soon.
+The Nipoppy version used in the tutorial videos was 0.4.5. Console output as well as certain flags could have changed between this version and newer versions. Please consult the release notes on [GitHub](https://github.com/nipoppy/nipoppy/releases) for details. E.g., the `--regenerate` flag for the `track-curation` command is deprecated.
 ```
 
 ## 1. nipoppy init

--- a/docs/source/tutorials/videos/index.md
+++ b/docs/source/tutorials/videos/index.md
@@ -10,7 +10,8 @@ $ git clone https://github.com/nipoppy/tutorial-dataset.git
 
 or visit the [GitHub repo](https://github.com/nipoppy/tutorial-dataset) and download the data without using `git`. We show in the videos how to!
 
-The Nipoppy version used in the tutorial videos was 0.4.5. Console output as well as certain flags could have changed between this version and newer versions. Please consult the release notes on [GitHub](https://github.com/nipoppy/nipoppy/releases) for details. E.g., the `--regenerate` flag for the `track-curation` command is deprecated.
+```{attention}
+The Nipoppy version used in the tutorial videos was 0.4.5. Console output as well as certain flags could have changed between this version and newer versions. Please consult the [release notes](../../other/changelog.rst) for details. E.g., the `--regenerate` flag for the `track-curation` command is deprecated.
 ```
 
 ## 1. nipoppy init

--- a/docs/source/tutorials/videos/index.md
+++ b/docs/source/tutorials/videos/index.md
@@ -10,6 +10,10 @@ $ git clone https://github.com/nipoppy/tutorial-dataset.git
 
 or visit the [GitHub repo](https://github.com/nipoppy/tutorial-dataset) and download the data without using `git`. We show in the videos how to!
 
+```{note}
+Nipoppy version used in the tutorial videos was 0.4.5. Console output as well as certain flags could have changed between this version and newer versions. Please consult the release notes on [GitHub](https://github.com/nipoppy/nipoppy/releases) for details. E.g., the `--regenerate` flag for the `track-curation` command will be deprecated soon.
+```
+
 ## 1. nipoppy init
 
 In this tutorial we will cover how to create a new Nipoppy dataset. More concretely, we will


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->

<!-- Add issue number -->
- related to #401 
<!-- - Related to # -->

<!-- Summarize proposed changes below -->
## Changes
Added a note on the tutorial videos page about which nipoppy version was used in the videos and also a warning that outputs in the terminal might look different and that flags might change, giving the example of `--regenerate`. I also put the same not on all youtube videos. 

<!-- DO NOT EDIT OR REMOVE -->
## Checklist
_This section is for the PR reviewer_

### All PRs
- [x] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [ ] Checks pass

### If new feature
- [ ] Tests have been added

### If bug fix
- [ ] There is at least one test that would fail under the original bug conditions
