### PR TITLE
[MAINT] Stop using the Boutiques Python API

### DIFF
--- a/nipoppy/pipeline_validation.py
+++ b/nipoppy/pipeline_validation.py
@@ -4,7 +4,6 @@ import json
 import logging
 from pathlib import Path
 
-import boutiques
 from pydantic_core import ValidationError
 
 from nipoppy.config.hpc import HpcConfig
@@ -22,6 +21,7 @@ from nipoppy.exceptions import ConfigError, FileOperationError
 from nipoppy.layout import DatasetLayout, LayoutError
 from nipoppy.logger import get_logger
 from nipoppy.utils.utils import TEMPLATE_REPLACE_PATTERN, load_json
+from nipoppy.workflows.base import _run_command
 
 logger = get_logger()
 
@@ -62,9 +62,7 @@ def _load_pipeline_config_file(
     return config
 
 
-def _check_descriptor_file(
-    fpath_descriptor: StrOrPathLike, strict: bool = False
-) -> str:
+def _check_descriptor_file(fpath_descriptor: StrOrPathLike, strict: bool = False):
     """Validate a Boutiques descriptor file."""
     fpath_descriptor: Path = Path(fpath_descriptor)
     if not fpath_descriptor.exists():
@@ -73,11 +71,16 @@ def _check_descriptor_file(
     descriptor_dict = load_json(fpath_descriptor)
 
     descriptor_str = json.dumps(descriptor_dict)
-    try:
-        boutiques.validate(descriptor_str)
-    except boutiques.DescriptorValidationError as exception:
+    process, (stdout, stderr) = _run_command(
+        ["bosh", "validate", str(fpath_descriptor)],
+        check=False,
+        log_command=False,
+        log_output=False,
+        capture_output=True,
+    )
+    if process.returncode != 0:
         raise ConfigError(
-            f"Descriptor file {fpath_descriptor} is invalid:\n{exception}"
+            f"Descriptor file {fpath_descriptor} is invalid:\n{stdout}\n{stderr}"
         )
 
     if TEMPLATE_REPLACE_PATTERN.search(descriptor_str) is not None:
@@ -94,10 +97,8 @@ def _check_descriptor_file(
                 + "This will be deprecated in the future: you should update this file following steps listed in https://nipoppy.readthedocs.io/en/0.4.1/changelog.html#release-0-4-1."  # noqa E501
             )
 
-    return descriptor_str
 
-
-def _check_invocation_file(fpath_invocation: Path, descriptor_str: str) -> None:
+def _check_invocation_file(fpath_invocation: Path, fpath_descriptor: Path) -> None:
     """Validate a Boutiques invocation file."""
     fpath_invocation: Path = Path(fpath_invocation)
     if not fpath_invocation.exists():
@@ -105,13 +106,22 @@ def _check_invocation_file(fpath_invocation: Path, descriptor_str: str) -> None:
 
     invocation_dict = load_json(fpath_invocation, allow_json5=True)
 
-    try:
-        boutiques.invocation(
-            "--invocation", json.dumps(invocation_dict), descriptor_str
-        )
-    except boutiques.InvocationValidationError as exception:
+    process, (stdout, stderr) = _run_command(
+        [
+            "bosh",
+            "invocation",
+            "--invocation",
+            json.dumps(invocation_dict),
+            str(fpath_descriptor),
+        ],
+        check=False,
+        log_command=False,
+        log_output=False,
+        capture_output=True,
+    )
+    if process.returncode != 0:
         raise ConfigError(
-            f"Invocation file {fpath_invocation} is invalid:\n{exception}"
+            f"Invocation file {fpath_invocation} is invalid:\n{stdout}\n{stderr}"
         )
 
 
@@ -202,7 +212,7 @@ def _check_pipeline_files(
                 msg=f"\tChecking descriptor file: {step.DESCRIPTOR_FILE}",
             )
             fpath_descriptor = dpath_bundle / step.DESCRIPTOR_FILE
-            descriptor_str = _check_descriptor_file(fpath_descriptor, strict=strict)
+            _check_descriptor_file(fpath_descriptor, strict=strict)
             fpaths.append(fpath_descriptor)
 
             if step.INVOCATION_FILE is not None:
@@ -211,7 +221,7 @@ def _check_pipeline_files(
                     msg=f"\tChecking invocation file: {step.INVOCATION_FILE}",
                 )
                 fpath_invocation = dpath_bundle / step.INVOCATION_FILE
-                _check_invocation_file(fpath_invocation, descriptor_str)
+                _check_invocation_file(fpath_invocation, fpath_descriptor)
                 fpaths.append(fpath_invocation)
 
         if step.HPC_CONFIG_FILE is not None:

--- a/nipoppy/workflows/base.py
+++ b/nipoppy/workflows/base.py
@@ -55,7 +55,7 @@ class CommandRunner(Protocol):
         /,
         *,
         check: bool = True,
-        quiet: bool = False,
+        log_command: bool = True,
         dry_run: bool = False,
     ) -> subprocess.Popen[str] | str:
         """Run a command in a subprocess, with logging and dry-run support."""
@@ -67,18 +67,20 @@ def _run_command(
     /,
     *,
     check: bool = True,
-    quiet: bool = False,
+    log_command: bool = True,
+    log_output: bool = True,
+    capture_output: bool = False,
     dry_run: bool = False,
     **kwargs,
-) -> subprocess.Popen[str] | str:
+) -> subprocess.Popen[str] | tuple[subprocess.Popen[str], tuple[str, str]] | str:
     """Run a command in a subprocess.
 
-    The command's stdout and stderr outputs are written to the log
-    with special prefixes.
+    If `log_command` is True, the command's stdout and stderr outputs are
+    written to the log with special prefixes.
 
     If in "dry run" mode, the command is not executed, and the method returns
-    the command string. Otherwise, the subprocess.Popen object is returned
-    unless capture_output is True.
+    the command string. Otherwise, the subprocess.Popen object is returned. If
+    `capture_output` is True, stdout and stderr output are returned as well.
 
     Parameters
     ----------
@@ -87,27 +89,42 @@ def _run_command(
     check : bool, optional
         If True, raise an error if the process exits with a non-zero code,
         by default True
-    quiet : bool, optional
-        If True, do not log the command, by default False
+    log_command : bool, optional
+        Whether or not to log the command, by default True
+    log_output : bool, optional
+        Whether or not to log the command output, by default True
+    capture_output : bool, optional
+        Whether or not to capture the output, by default False
+    dry_run : bool, optional
+        If True, do not execute the command, by default False
     **kwargs
         Passed to `subprocess.Popen`.
 
     Returns
     -------
-    subprocess.Popen or str
+    subprocess.Popen[str] or tuple[subprocess.Popen[str], tuple[str, str]] or str
+        The subprocess.Popen object if the command was executed, or the command
+        string if in dry run mode. If `capture_output` is True, a tuple of the
+        subprocess.Popen object and a tuple of (stdout, stderr) strings is
+        returned.
     """
 
-    def process_output(output_source, log_prefix: str, log_level=logging.INFO):
+    def process_output(
+        output_source, log_prefix: str, output_list: list, log_level=logging.INFO
+    ):
         """Consume lines from an IO stream and log them."""
         for line in output_source:
             line = line.strip("\n")
-            # using extra={"markup": False} in case the output contains substrings
-            # that would be interpreted as closing tags by the RichHandler
-            logger.log(
-                level=log_level,
-                msg=f"{log_prefix} {line}",
-                extra={"markup": False},
-            )
+            if log_output:
+                # using extra={"markup": False} in case the output contains substrings
+                # that would be interpreted as closing tags by the RichHandler
+                logger.log(
+                    level=log_level,
+                    msg=f"{log_prefix} {line}",
+                    extra={"markup": False},
+                )
+            if output_list is not None:
+                output_list.append(line)
 
     # build command string
     if not isinstance(command_or_args, str):
@@ -121,7 +138,7 @@ def _run_command(
     if not kwargs.get("shell"):
         command_or_args = args
 
-    if not quiet:
+    if log_command:
         _log_command(command)
 
     if not dry_run:
@@ -133,22 +150,31 @@ def _run_command(
             **kwargs,
         )
 
+        stdout_list = []
+        stderr_list = []
         while process.poll() is None:
             process_output(
                 process.stdout,
                 LogPrefix.RUN_STDOUT,
+                stdout_list,
             )
 
             process_output(
                 process.stderr,
                 LogPrefix.RUN_STDERR,
+                stderr_list,
                 log_level=logging.ERROR,
             )
 
         if check and process.returncode != 0:
             raise subprocess.CalledProcessError(process.returncode, command)
 
-        run_output = process
+        if capture_output:
+            stdout = "\n".join(stdout_list)
+            stderr = "\n".join(stderr_list)
+            run_output = (process, (stdout, stderr))
+        else:
+            run_output = process
 
     else:
         run_output = command

--- a/nipoppy/workflows/pipeline_store/create.py
+++ b/nipoppy/workflows/pipeline_store/create.py
@@ -3,8 +3,6 @@
 import warnings
 from pathlib import Path
 
-import boutiques
-
 from nipoppy.env import PROGRAM_VERSION, PipelineTypeEnum
 from nipoppy.exceptions import FileOperationError, WorkflowError
 from nipoppy.layout import DatasetLayout
@@ -13,7 +11,7 @@ from nipoppy.pipeline_validation import _load_pipeline_config_file
 from nipoppy.utils import fileops
 from nipoppy.utils.json5 import update_json5_file
 from nipoppy.utils.utils import TEMPLATE_PIPELINE_PATH, load_json
-from nipoppy.workflows.base import BaseWorkflow
+from nipoppy.workflows.base import BaseWorkflow, _run_command
 
 logger = get_logger()
 
@@ -66,20 +64,26 @@ class PipelineCreateWorkflow(BaseWorkflow):
 
         descriptor_path = target.joinpath(pipeline_step_config.DESCRIPTOR_FILE)
         if source_descriptor:
-            try:
-                boutiques.validate(str(source_descriptor))
-            except boutiques.DescriptorValidationError as exception:
+            process, (stdout, stderr) = _run_command(
+                ["bosh", "validate", str(source_descriptor)],
+                check=False,
+                log_command=False,
+                log_output=False,
+                capture_output=True,
+            )
+            if process.returncode != 0:
                 raise WorkflowError(
-                    f"Descriptor file {source_descriptor} is invalid:\n{exception}"
-                )
-            except ValueError as exception:  # catches simplejson.errors.JSONDecodeError
-                raise WorkflowError(
-                    "Error validating the descriptor file "
-                    f"{source_descriptor}:\n{exception}"
+                    f"Error validating the descriptor file {source_descriptor}:"
+                    f"\n{stdout}\n{stderr}"
                 )
             fileops.copy(source_descriptor, descriptor_path, dry_run=self.dry_run)
         else:
-            boutiques.create(str(descriptor_path))
+            _run_command(
+                ["bosh", "create", str(descriptor_path)],
+                check=True,
+                log_command=False,
+                log_output=False,
+            )
 
         substitutions = {"version": PROGRAM_VERSION}
 
@@ -92,8 +96,15 @@ class PipelineCreateWorkflow(BaseWorkflow):
             dry_run=self.dry_run,
         )
         # then append the actual example invocation
+        _, (stdout, _) = _run_command(
+            ["bosh", "example", str(descriptor_path)],
+            check=True,
+            log_command=False,
+            log_output=False,
+            capture_output=True,
+        )
         with invocation_path.open("a") as file_invocation:
-            file_invocation.write(boutiques.example(str(descriptor_path)))
+            file_invocation.write(stdout)
 
         fileops.copy_template(
             TEMPLATE_PIPELINE_PATH.joinpath(pipeline_step_config.HPC_CONFIG_FILE),

--- a/nipoppy/workflows/runner.py
+++ b/nipoppy/workflows/runner.py
@@ -7,7 +7,6 @@ from abc import ABC
 from functools import cached_property
 from pathlib import Path
 
-from boutiques import bosh
 from typing_extensions import override
 
 from nipoppy.config.boutiques import BoutiquesConfig
@@ -233,10 +232,7 @@ class Runner(BasePipelineWorkflow, ABC):
                     case ContainerCommandEnum.DOCKER:
                         bosh_exec_launch_args.append("--force-docker")
 
-        # validate the descriptor
         logger.debug(f"Descriptor string: {descriptor_str}")
-        logger.info("Validating the JSON descriptor")
-        bosh(["validate", descriptor_str])
 
         # process and validate the invocation
         logger.info("Processing the JSON invocation")
@@ -249,8 +245,6 @@ class Runner(BasePipelineWorkflow, ABC):
             return_str=True,
         )
         logger.debug(f"Invocation string: {invocation_str}")
-        logger.info("Validating the JSON invocation")
-        bosh(["invocation", "-i", invocation_str, descriptor_str])
 
         # run as a subprocess so that stdout/error are captured in the log
         # by default, this will raise an exception if the command fails

--- a/nipoppy/workflows/runner.py
+++ b/nipoppy/workflows/runner.py
@@ -208,7 +208,7 @@ class Runner(BasePipelineWorkflow, ABC):
             else:
                 bosh_exec_launch_args.extend(
                     [
-                        "--no-automount",
+                        "--no-automounts",
                         f"--container-opts={shlex.join(container_handler.args)}",
                     ]
                 )

--- a/nipoppy/workflows/services/boutiques.py
+++ b/nipoppy/workflows/services/boutiques.py
@@ -85,7 +85,7 @@ def _run_bosh_command(
     logger.info(f"{mode} pipeline command")
 
     try:
-        run_command(command, quiet=True, dry_run=dry_run)
+        run_command(command, log_command=False, dry_run=dry_run)
     except subprocess.CalledProcessError as exception:
         raise ExecutionError(error_message_builder(exception.returncode))
 

--- a/tests/unit/test_pipeline_validation.py
+++ b/tests/unit/test_pipeline_validation.py
@@ -32,12 +32,6 @@ from tests.conftest import DPATH_TEST_DATA
 
 
 @pytest.fixture()
-def descriptor_str():
-    """Fixture for _check_invocation_file."""
-    return Path(DPATH_TEST_DATA / "descriptor-valid.json").read_text()
-
-
-@pytest.fixture()
 def valid_config_data():
     """Minimal data for a valid BasePipelineConfig."""
     return {
@@ -81,9 +75,7 @@ def test_load_pipeline_config_file_invalid(fpath, exception_class, exception_mes
 
 
 def test_check_descriptor_file(caplog: pytest.LogCaptureFixture):
-    assert isinstance(
-        _check_descriptor_file(DPATH_TEST_DATA / "descriptor-valid.json"), str
-    )
+    _check_descriptor_file(DPATH_TEST_DATA / "descriptor-valid.json")
     assert len(caplog.records) == 0
 
 
@@ -135,8 +127,13 @@ def test_check_descriptor_file_invalid(fpath, exception_class, exception_message
         _check_descriptor_file(fpath)
 
 
-def test_check_invocation_file(descriptor_str):
-    _check_invocation_file(DPATH_TEST_DATA / "invocation-valid.json5", descriptor_str)
+def test_check_invocation_file(caplog: pytest.LogCaptureFixture):
+    _check_invocation_file(
+        DPATH_TEST_DATA / "invocation-valid.json5",
+        DPATH_TEST_DATA / "descriptor-valid.json",
+    )
+
+    assert len(caplog.records) == 0
 
 
 @pytest.mark.parametrize(
@@ -150,11 +147,9 @@ def test_check_invocation_file(descriptor_str):
         ),
     ],
 )
-def test_check_invocation_file_invalid(
-    fpath, exception_class, exception_message, descriptor_str
-):
+def test_check_invocation_file_invalid(fpath, exception_class, exception_message):
     with pytest.raises(exception_class, match=exception_message):
-        _check_invocation_file(fpath, descriptor_str)
+        _check_invocation_file(fpath, DPATH_TEST_DATA / "descriptor-valid.json")
 
 
 def test_check_hpc_config_file():

--- a/tests/unit/workflows/pipeline_store/test_create.py
+++ b/tests/unit/workflows/pipeline_store/test_create.py
@@ -157,18 +157,11 @@ def test_create_from_descriptor(workflow: PipelineCreateWorkflow):
     )
 
 
-@pytest.mark.parametrize(
-    "file_content,exception_message",
-    [
-        ("", "Error validating the descriptor file .*:"),
-        ("{}", "Descriptor file .* is invalid:"),
-    ],
-)
+@pytest.mark.parametrize("file_content", ["", "{}"])
 def test_create_invalid_descriptor(
     tmp_path: Path,
     workflow: PipelineCreateWorkflow,
     file_content: str,
-    exception_message: str,
 ):
     """Test the behavior when the source descriptor is invalid."""
     source_descriptor = tmp_path / "bad_descriptor.json"
@@ -176,5 +169,5 @@ def test_create_invalid_descriptor(
 
     workflow.source_descriptor = source_descriptor
 
-    with pytest.raises(WorkflowError, match=exception_message):
+    with pytest.raises(WorkflowError, match="Error validating the descriptor file .*:"):
         workflow.run_main()

--- a/tests/unit/workflows/test_base.py
+++ b/tests/unit/workflows/test_base.py
@@ -106,8 +106,18 @@ def test_run_command_no_markup(caplog: pytest.LogCaptureFixture, tmp_path: Path)
 
 
 @pytest.mark.no_xdist
-def test_run_command_no_log_command(caplog: pytest.LogCaptureFixture):
+def test_run_command_log_command_false(caplog: pytest.LogCaptureFixture):
     message = "This should be printed"
     _run_command(["echo", message], log_command=False)
     assert LogPrefix.RUN not in caplog.text
+    assert LogPrefix.RUN_STDOUT in caplog.text
+    assert message in caplog.text
+
+
+@pytest.mark.no_xdist
+def test_run_command_log_output_false(caplog: pytest.LogCaptureFixture):
+    message = "This should be printed"
+    _run_command(["echo", message], log_output=False)
+    assert LogPrefix.RUN in caplog.text
+    assert LogPrefix.RUN_STDOUT not in caplog.text
     assert message in caplog.text

--- a/tests/unit/workflows/test_base.py
+++ b/tests/unit/workflows/test_base.py
@@ -65,6 +65,14 @@ def test_run_command(tmp_path: Path):
     assert fpath.exists()
 
 
+def test_run_command_capture_output(tmp_path: Path):
+    fpath = tmp_path / "test.txt"
+    process, (stdout, stderr) = _run_command(["echo", fpath], capture_output=True)
+    assert process.returncode == 0
+    assert stdout == str(fpath)
+    assert stderr == ""
+
+
 def test_run_command_single_string(tmp_path: Path):
     fpath = tmp_path / "test.txt"
     process = _run_command(f"touch {fpath}", shell=True)
@@ -97,8 +105,8 @@ def test_run_command_no_markup(caplog: pytest.LogCaptureFixture, tmp_path: Path)
 
 
 @pytest.mark.no_xdist
-def test_run_command_quiet(caplog: pytest.LogCaptureFixture):
+def test_run_command_no_log_command(caplog: pytest.LogCaptureFixture):
     message = "This should be printed"
-    _run_command(["echo", message], quiet=True)
+    _run_command(["echo", message], log_command=False)
     assert LogPrefix.RUN not in caplog.text
     assert message in caplog.text

--- a/tests/unit/workflows/test_base.py
+++ b/tests/unit/workflows/test_base.py
@@ -65,6 +65,7 @@ def test_run_command(tmp_path: Path):
     assert fpath.exists()
 
 
+@pytest.mark.no_xdist
 def test_run_command_capture_output(tmp_path: Path):
     fpath = tmp_path / "test.txt"
     process, (stdout, stderr) = _run_command(["echo", fpath], capture_output=True)

--- a/tests/unit/workflows/test_runner.py
+++ b/tests/unit/workflows/test_runner.py
@@ -346,7 +346,7 @@ def test_launch_boutiques_run(
             ApptainerHandler(),
             [
                 "--force-apptainer",
-                "--no-automount",
+                "--no-automounts",
                 "--imagepath",
                 "--container-opts=",
             ],
@@ -355,7 +355,7 @@ def test_launch_boutiques_run(
             SingularityHandler(),
             [
                 "--force-singularity",
-                "--no-automount",
+                "--no-automounts",
                 "--imagepath",
                 "--container-opts=",
             ],
@@ -364,7 +364,7 @@ def test_launch_boutiques_run(
             DockerHandler(),
             [
                 "--force-docker",
-                "--no-automount",
+                "--no-automounts",
                 "--container-opts=",
             ],
         ),

--- a/tests/unit/workflows/test_runner.py
+++ b/tests/unit/workflows/test_runner.py
@@ -335,7 +335,7 @@ def test_launch_boutiques_run(
     assert "[[NIPOPPY_BIDS_SESSION_ID]]" not in invocation_str
 
     assert mocked_run_command.call_count == 1
-    assert mocked_run_command.call_args[1].get("quiet") is True
+    assert mocked_run_command.call_args[1].get("log_command") is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->

<!-- Add issue number -->
- Closes none
<!-- - Related to # -->

<!-- Summarize proposed changes below -->
## Changes
- Only use the `bosh` CLI via Python subprocess
- Update `nipoppy.workflows.base._run_command` to allow output capturing, which is used for the default invocation file creation and for validation error reporting
    - Not entirely satisfied with the implementation of the validation error reporting. Ideally we would rely on the existing logger functionalities, but because we always log both stdout and stderr that means there will be an `OK` logged with e.g., valid descriptors
- Currently working with latest official Boutiques. Need to test with [github.com/childmindresearch/boutiques_next](https://github.com/childmindresearch/boutiques_next)

<!-- DO NOT EDIT OR REMOVE -->
## Checklist
_This section is for the PR reviewer_

### All PRs
- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

### If new feature
- [ ] Tests have been added

### If bug fix
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--1128.org.readthedocs.build/en/1128/

<!-- readthedocs-preview nipoppy end -->