### PR TITLE
[MAINT] Harmonize null checks to use is None or is not None

### DIFF
--- a/nipoppy/cli/cli.py
+++ b/nipoppy/cli/cli.py
@@ -108,7 +108,7 @@ def cli():
     """Organize and process neuroimaging-clinical datasets."""
 
 
-if cli.commands.get("gui"):
+if cli.commands.get("gui") is not None:
     cli.commands["gui"].hidden = True
 
 

--- a/nipoppy/cli/options.py
+++ b/nipoppy/cli/options.py
@@ -28,8 +28,9 @@ def dataset_option(func):
 def dep_params(**params):
     """Handle deprecated parameters."""
     # --write-list is deprecated by --write-subcohort
-    if "write_subcohort" in params and (
-        _dep_write_subcohort := params.pop("write_list")
+    if (
+        "write_subcohort" in params
+        and (_dep_write_subcohort := params.pop("write_list")) is not None
     ):
         logger.warning(
             "The --write-list option is deprecated and will be removed in a future "

--- a/nipoppy/container.py
+++ b/nipoppy/container.py
@@ -48,7 +48,7 @@ class ContainerHandler(Base, ABC):
 
     def check_command_exists(self):
         """Check that the command is available (i.e. in PATH)."""
-        if not shutil.which(self.command):
+        if shutil.which(self.command) is None:
             raise ContainerError(
                 f"Container executable not found: {self.command}"
                 ". Make sure it is installed and in your PATH."

--- a/nipoppy/logger.py
+++ b/nipoppy/logger.py
@@ -79,7 +79,7 @@ class NipoppyLogger(logging.Logger):
         handler : logging.Handler
             The handler to remove.
         """
-        if handler:
+        if handler is not None:
             handler.close()
             self.removeHandler(handler)
 

--- a/nipoppy/workflows/dataset_init.py
+++ b/nipoppy/workflows/dataset_init.py
@@ -123,7 +123,10 @@ class InitWorkflow(BaseDatasetWorkflow):
             )
 
         # copy dataset description file if specified in layout
-        if getattr(self.study.layout, "fpath_bids_dataset_description", None):
+        if (
+            getattr(self.study.layout, "fpath_bids_dataset_description", None)
+            is not None
+        ):
             fileops.copy_template(
                 FPATH_SAMPLE_BIDS_DATASET_DESCRIPTION,
                 self.study.layout.fpath_bids_dataset_description,
@@ -133,7 +136,7 @@ class InitWorkflow(BaseDatasetWorkflow):
             )
 
         # copy bidsignore file if specified in layout
-        if getattr(self.study.layout, "fpath_bidsignore", None):
+        if getattr(self.study.layout, "fpath_bidsignore", None) is not None:
             fileops.copy(
                 FPATH_SAMPLE_BIDSIGNORE,
                 self.study.layout.fpath_bidsignore,

--- a/nipoppy/workflows/pipeline.py
+++ b/nipoppy/workflows/pipeline.py
@@ -160,7 +160,7 @@ class BasePipelineWorkflow(BaseDatasetWorkflow, ABC):
         _skip_logfile: bool = False,
         _show_progress: bool = False,
     ):
-        if hpc and write_subcohort:
+        if hpc is not None and write_subcohort is not None:
             raise WorkflowError(
                 "HPC job submission and writing a list of participants and sessions "
                 "are mutually exclusive."
@@ -749,7 +749,7 @@ class BasePipelineWorkflow(BaseDatasetWorkflow, ABC):
 
     def _log_summary_message(self):
         """Log a summary message."""
-        if self.write_subcohort:
+        if self.write_subcohort is not None:
             logger.success(f"Wrote subcohort to {self.write_subcohort}")
         elif self.n_total == 0:
             logger.warning(

--- a/nipoppy/workflows/pipeline_store/create.py
+++ b/nipoppy/workflows/pipeline_store/create.py
@@ -65,7 +65,7 @@ class PipelineCreateWorkflow(BaseWorkflow):
         ).get_step_config()
 
         descriptor_path = target.joinpath(pipeline_step_config.DESCRIPTOR_FILE)
-        if source_descriptor:
+        if source_descriptor is not None:
             try:
                 boutiques.validate(str(source_descriptor))
             except boutiques.DescriptorValidationError as exception:

--- a/nipoppy/workflows/runner.py
+++ b/nipoppy/workflows/runner.py
@@ -174,7 +174,7 @@ class Runner(BasePipelineWorkflow, ABC):
 
         # process the descriptor if it containers Nipoppy-specific placeholder
         # expressions (legacy behaviour)
-        if TEMPLATE_REPLACE_PATTERN.search(self.descriptor["command-line"]):
+        if TEMPLATE_REPLACE_PATTERN.search(self.descriptor["command-line"]) is not None:
             logger.info("Processing the JSON descriptor")
             descriptor_str = self.process_template_json(
                 self.descriptor,
@@ -326,7 +326,7 @@ class Runner(BasePipelineWorkflow, ABC):
         """
         if self.write_subcohort is not None:
             self._write_subcohort_to_file(participants_sessions)
-        elif self.hpc:
+        elif self.hpc is not None:
             self._submit_hpc_job(participants_sessions)
         else:
             self._run_locally(participants_sessions)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -358,7 +358,7 @@ def test_cli_command(
     # Hack to inject the mocked directory into the command
     command = [arg.replace("[mocked_dir]", str(mocked_dir)) for arg in command]
 
-    if workflow:
+    if workflow is not None:
         mocker.patch(f"{workflow}.run")
     _assert_command_success(command)
 


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->

<!-- Add issue number -->
- Closes #937 
<!-- - Related to # -->

**Question**
Should we still use the long form (`is not None`) when check `getattr(..., None)`?
e.g. changes nipoppy/workflows/dataset_init.py

**AI use**: GPT-5.6 Luna max did the changes and I reviewed them.

<!-- DO NOT EDIT OR REMOVE -->
## Checklist
_This section is for the PR reviewer_

### All PRs
- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

### If new feature
- [ ] Tests have been added

### If bug fix
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--1131.org.readthedocs.build/en/1131/

<!-- readthedocs-preview nipoppy end -->