### PR TITLE
[BUG] Fail early when manifest is empty and using BIDS source

### DIFF
--- a/nipoppy/utils/fileops.py
+++ b/nipoppy/utils/fileops.py
@@ -33,11 +33,17 @@ def copy(source: Path, target: Path, dry_run=False, exist_ok: bool = False):
     """
     Copy a file or directory.
 
-    Raise an error by default if the target path already exists.
+    Creates missing parent directories.
+
+    Raises
+    ------
+    FileOperationError
+        If the target path already exists and `exist_ok` is False.
     """
     if target.exists() and not exist_ok:
         raise FileOperationError(f"Target already exists: {target}")
 
+    mkdir(target.parent, dry_run=dry_run)
     logger.debug(f"Copying {source} to {target}")
     if not dry_run:
         if source.is_file():
@@ -66,7 +72,6 @@ def copy_template(
         Key-value pairs passed to process_template_str for substitution
     """
     logger.debug(f"Copying template {source} to {dest}")
-    mkdir(dest.parent, dry_run=dry_run)
     copy(source, dest, dry_run=dry_run, exist_ok=exist_ok)
     if not dry_run:
         dest.write_text(

--- a/nipoppy/workflows/dataset_init.py
+++ b/nipoppy/workflows/dataset_init.py
@@ -317,7 +317,7 @@ class InitWorkflow(BaseDatasetWorkflow):
         manifest = Manifest(df).validate()
         if manifest.empty:
             raise WorkflowError(
-                "Cannot initialize an empty manifest: no subjects found in BIDS source "
+                "No subjects found in BIDS source "
                 f"directory {self.bids_source}. Expected {BIDS_SUBJECT_PREFIX}* "
                 "directories directly inside it."
             )

--- a/nipoppy/workflows/dataset_init.py
+++ b/nipoppy/workflows/dataset_init.py
@@ -16,7 +16,7 @@ from nipoppy.env import (
     PipelineTypeEnum,
     StrOrPathLike,
 )
-from nipoppy.exceptions import FileOperationError
+from nipoppy.exceptions import FileOperationError, WorkflowError
 from nipoppy.logger import get_logger
 from nipoppy.tabular.manifest import Manifest
 from nipoppy.utils import fileops
@@ -79,11 +79,26 @@ class InitWorkflow(BaseDatasetWorkflow):
         """
         self._validate_study_root()
 
+        if self.bids_source is None:
+            fileops.copy(
+                FPATH_SAMPLE_MANIFEST,
+                self.study.layout.fpath_manifest,
+                exist_ok=True,
+                dry_run=self.dry_run,
+            )
+            logger.warning(
+                f"Sample manifest file copied to {self.study.layout.fpath_manifest}. "
+                "It should be edited to match your dataset."
+            )
+        else:
+            self._handle_bids_source()
+            self._init_manifest_from_bids_dataset()
+
         # create directories
         fileops.mkdir(self.dpath_root / NIPOPPY_DIR_NAME, dry_run=self.dry_run)
         for dpath in self.study.layout.get_paths(directory=True, include_optional=True):
             if self.bids_source is not None and dpath == self.study.layout.dpath_bids:
-                self._handle_bids_source()
+                continue
             elif (
                 self.container_store is not None
                 and dpath == self.study.layout.dpath_containers
@@ -106,21 +121,6 @@ class InitWorkflow(BaseDatasetWorkflow):
 
         # config file
         self._create_config_file()
-
-        # manifest
-        if self.bids_source is not None:
-            self._init_manifest_from_bids_dataset()
-        else:
-            fileops.copy(
-                FPATH_SAMPLE_MANIFEST,
-                self.study.layout.fpath_manifest,
-                exist_ok=True,
-                dry_run=self.dry_run,
-            )
-            logger.warning(
-                f"Sample manifest file copied to {self.study.layout.fpath_manifest}. "
-                "It should be edited to match your dataset."
-            )
 
         # copy dataset description file if specified in layout
         if getattr(self.study.layout, "fpath_bids_dataset_description", None):
@@ -315,6 +315,12 @@ class InitWorkflow(BaseDatasetWorkflow):
         df[Manifest.col_visit_id] = df[Manifest.col_session_id]
 
         manifest = Manifest(df).validate()
+        if manifest.empty:
+            raise WorkflowError(
+                "Cannot initialize an empty manifest: no subjects found in BIDS source "
+                f"directory {self.bids_source}. Expected {BIDS_SUBJECT_PREFIX}* "
+                "directories directly inside it."
+            )
         manifest.save_with_backup(
             self.study.layout.fpath_manifest, dry_run=self.dry_run
         )

--- a/tests/unit/utils/test_fileops.py
+++ b/tests/unit/utils/test_fileops.py
@@ -157,6 +157,29 @@ class TestMakeDir:
 
 
 class TestCopy:
+    @pytest.mark.parametrize("is_directory", [False, True], ids=["file", "directory"])
+    @pytest.mark.parametrize("dry_run", [False, True])
+    def test_cp_creates_parents(
+        self, tmp_path: Path, is_directory: bool, dry_run: bool
+    ):
+        """Test copying into missing parents without creating them during dry runs."""
+        source = tmp_path / "source"
+        target = tmp_path / "missing" / "nested" / "target"
+        if is_directory:
+            create_dummy_directory_structure(source)
+        else:
+            source.write_text("content")
+
+        fileops.copy(source, target, dry_run=dry_run)
+
+        if dry_run:
+            assert not (tmp_path / "missing").exists()  # Parent dir not created
+            assert not target.exists()
+        elif is_directory:
+            check_dummy_directory_structure(target)
+        else:
+            assert target.read_text() == "content"
+
     @pytest.mark.parametrize(
         "exist_ok, raises_error, final_content",
         [
@@ -213,16 +236,6 @@ class TestCopyTemplate:
         fileops.copy_template(template_file, dest_file, substitutions={"name": "World"})
 
         assert dest_file.is_file()
-        assert dest_file.read_text() == "Hello, World!"
-
-    def test_copy_template_creates_parent_directory(self, tmp_path: Path):
-        """Test that the parent directory of the destination is created."""
-        template_file = tmp_path / "template.txt"
-        template_file.write_text("Hello, [[NIPOPPY_NAME]]!")
-
-        dest_file = tmp_path / "nonexistent_dir" / "output.txt"
-
-        fileops.copy_template(template_file, dest_file, substitutions={"name": "World"})
         assert dest_file.read_text() == "Hello, World!"
 
     def test_copy_template_existing_file(self, tmp_path: Path):

--- a/tests/unit/workflows/test_init.py
+++ b/tests/unit/workflows/test_init.py
@@ -1,6 +1,7 @@
 """Tests for the dataset init workflow."""
 
 import os
+import re
 import shutil
 import subprocess
 from collections.abc import Generator
@@ -12,10 +13,16 @@ import pytest_mock
 from fids import fids
 
 from nipoppy.env import FAKE_SESSION_ID, PROGRAM_VERSION
-from nipoppy.exceptions import FileOperationError
+from nipoppy.exceptions import FileOperationError, WorkflowError
 from nipoppy.tabular.manifest import Manifest
 from nipoppy.utils import fileops
-from nipoppy.utils.utils import DPATH_HPC, DPATH_LAYOUTS, FPATH_SAMPLE_CONFIG, load_json
+from nipoppy.utils.utils import (
+    DPATH_HPC,
+    DPATH_LAYOUTS,
+    FPATH_SAMPLE_CONFIG,
+    FPATH_SAMPLE_MANIFEST,
+    load_json,
+)
 from nipoppy.workflows.dataset_init import InitWorkflow
 
 
@@ -113,6 +120,13 @@ def _assert_layout_creation(workflow):
     # check that all directories have been created (using layout-aware paths)
     for dpath in workflow.study.layout.get_paths(directory=True, include_optional=True):
         assert dpath.exists(), f"Expected directory not found: {dpath}"
+        if (
+            workflow.bids_source is not None
+            and dpath == workflow.study.layout.dpath_bids
+        ):
+            # BIDS source directory should be copied/moved/symlinked without
+            # modifications to its contents.
+            continue
         # Check README exists for directories with descriptions (except .nipoppy)
         if dpath != workflow.study.layout.dpath_nipoppy and not dpath.is_symlink():
             readme_path = dpath / "README.md"
@@ -155,10 +169,32 @@ def assert_config_matches(fpath_actual: Path, fpath_expected: Path):
 
 
 @pytest.mark.no_xdist
-def test_run(workflow: InitWorkflow, caplog: pytest.LogCaptureFixture):
+@pytest.mark.parametrize(
+    "fname_layout",
+    ["layout-default.json", "layout-bids-study.json", "layout-0.1.0.json"],
+)
+@pytest.mark.parametrize("dry_run", [False, True])
+def test_run(
+    dpath_root: Path,
+    caplog: pytest.LogCaptureFixture,
+    fname_layout: str,
+    dry_run: bool,
+):
+    workflow = InitWorkflow(
+        dpath_root=dpath_root,
+        fpath_layout=DPATH_LAYOUTS / fname_layout,
+        dry_run=dry_run,
+    )
     workflow.run()
 
-    _assert_layout_creation(workflow)
+    if dry_run:
+        assert not dpath_root.exists()
+    else:
+        _assert_layout_creation(workflow)
+        assert (
+            workflow.study.layout.fpath_manifest.read_text()
+            == FPATH_SAMPLE_MANIFEST.read_text()
+        )
 
     assert f"Successfully initialized a dataset at {workflow.dpath_root}" in caplog.text
 
@@ -438,11 +474,17 @@ def test_bids_study_layout_passes_validation(dpath_root: Path):
     assert result.returncode == 0
 
 
+@pytest.mark.parametrize("mode", ["copy", "move", "symlink"])
+@pytest.mark.parametrize(
+    "fname_layout", ["layout-default.json", "layout-bids-study.json"]
+)
 def test_init_bids(
-    workflow: InitWorkflow,
+    dpath_root: Path,
     fake_bids_root: Path,
     mocker: pytest_mock.MockerFixture,
     caplog: pytest.LogCaptureFixture,
+    mode: str,
+    fname_layout: str,
 ):
     """Test init from an existing BIDS dataset.
 
@@ -451,7 +493,12 @@ def test_init_bids(
     - handle_bids_source is called
     - README has been created
     """
-    workflow.bids_source = fake_bids_root
+    workflow = InitWorkflow(
+        dpath_root=dpath_root,
+        bids_source=fake_bids_root,
+        mode=mode,
+        fpath_layout=DPATH_LAYOUTS / fname_layout,
+    )
 
     mocked_handle_bids_source = mocker.patch.object(
         workflow, "_handle_bids_source", wraps=workflow._handle_bids_source
@@ -463,6 +510,41 @@ def test_init_bids(
     _assert_manifest_creation(workflow)
     mocked_handle_bids_source.assert_called_once()
     assert "Sample manifest file copied" not in caplog.text
+
+
+@pytest.mark.parametrize("mode", ["copy", "move", "symlink"])
+@pytest.mark.parametrize("nested", [False, True], ids=["empty", "nested-bids"])
+def test_init_bids_empty_manifest(
+    workflow: InitWorkflow,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    mode: str,
+    nested: bool,
+):
+    bids_source = tmp_path / "bids"
+    bids_source.mkdir()
+    if nested:
+        (bids_source / "bids" / "sub-01" / "ses-1" / "anat").mkdir(parents=True)
+
+    workflow.bids_source = bids_source
+    workflow.mode = mode
+
+    with pytest.raises(
+        WorkflowError,
+        match=re.escape(
+            "Cannot initialize an empty manifest: no subjects found in BIDS source "
+            f"directory {str(bids_source)}. "
+            "Expected sub-* directories directly inside it."
+        ),
+    ):
+        workflow.run()
+
+    assert workflow.study.layout.dpath_bids.is_dir()
+    assert workflow.study.layout.dpath_bids.is_symlink() == (mode == "symlink")
+    assert bids_source.exists() == (mode != "move")
+    # Failing to create the manifest from a BIDS dataset should fail immediately.
+    assert list(workflow.dpath_root.iterdir()) == [workflow.study.layout.dpath_bids]
+    assert "Successfully initialized a dataset" not in caplog.text
 
 
 def test_handle_bids_source_invalid_mode(workflow: InitWorkflow, fake_bids_root: Path):
@@ -523,10 +605,12 @@ def test_init_bids_readonly(
     assert not (workflow.study.layout.dpath_bids / "README.md").exists()
 
 
-def test_init_bids_dry_run(workflow: InitWorkflow, fake_bids_root: Path):
+@pytest.mark.parametrize("mode", ["copy", "move", "symlink"])
+def test_init_bids_dry_run(workflow: InitWorkflow, fake_bids_root: Path, mode: str):
     """Copy no file when running in dry mode."""
     dpath_root = workflow.study.layout.dpath_root
     workflow.bids_source = fake_bids_root
+    workflow.mode = mode
     workflow.dry_run = True
     workflow.run()
 


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->

<!-- Add issue number -->
- Closes #897
<!-- - Related to # -->

<!-- Summarize proposed changes below -->
## Changes
- Raise error when manifest is empty from bids initialization.
- Init workflow now creates the bids and check the manifest first in the workflow.
- fileops.copy creates the parent dir to prevent failure.

<!-- DO NOT EDIT OR REMOVE -->
## Checklist
_This section is for the PR reviewer_

### All PRs
- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

### If new feature
- [ ] Tests have been added

### If bug fix
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--1132.org.readthedocs.build/en/1132/

<!-- readthedocs-preview nipoppy end -->