### PR TITLE
[BUG] Prevent overidding pipeline bundle when installing from same location

### DIFF
--- a/nipoppy/workflows/pipeline_store/install.py
+++ b/nipoppy/workflows/pipeline_store/install.py
@@ -253,29 +253,38 @@ class PipelineInstallWorkflow(BaseDatasetWorkflow):
             pipeline_config.VERSION,
         )
 
-        # check if the target directory already exists
-        if dpath_target.exists():
-            if not self.force:
-                raise FileOperationError(
-                    f"Pipeline directory exists: {dpath_target}"
-                    ". Use --force to overwrite",
+        if dpath_target.resolve() != dpath_pipeline.resolve():
+            # check if the target directory already exists
+            if dpath_target.exists():
+                if not self.force:
+                    raise FileOperationError(
+                        f"Pipeline directory exists: {dpath_target}"
+                        ". Use --force to overwrite",
+                    )
+                else:
+                    fileops.rm(dpath_target, dry_run=self.dry_run)
+
+            # copy the directory
+            if self.dpath_pipeline is not None:
+                fileops.copy(
+                    source=dpath_pipeline,
+                    target=dpath_target,
+                    dry_run=self.dry_run,
                 )
             else:
-                fileops.rm(dpath_target, dry_run=self.dry_run)
-
-        # copy the directory
-        if self.dpath_pipeline is not None:
-            fileops.copy(
-                source=dpath_pipeline,
-                target=dpath_target,
-                dry_run=self.dry_run,
-            )
+                # move downloaded pipelines to the target location
+                fileops.movetree(
+                    source=dpath_pipeline,
+                    target=dpath_target,
+                    dry_run=self.dry_run,
+                )
         else:
-            # if the pipeline was downloaded from Zenodo, move it to the target location
-            fileops.movetree(
-                source=dpath_pipeline,
-                target=dpath_target,
-                dry_run=self.dry_run,
+            logger.warning(
+                "Source and destination are the same directory; "
+                "skipping pipeline file operations. Editing an installed pipeline "
+                "in place is not recommended, as accidental changes can compromise "
+                "reproducibility. Keep pipeline development separate from the "
+                "installed copy."
             )
 
         # update global config with new pipeline variables

--- a/tests/unit/workflows/pipeline_store/test_install.py
+++ b/tests/unit/workflows/pipeline_store/test_install.py
@@ -436,6 +436,7 @@ def test_run_main(
     mocked_update_config_and_save.assert_called_once_with(pipeline_config)
     mocked_download_container.assert_called_once_with(pipeline_config)
     assert "Successfully installed pipeline" in caplog.text
+    assert "Source and destination are the same directory" not in caplog.text
 
 
 @pytest.mark.parametrize("force", [False, True])
@@ -461,6 +462,39 @@ def test_run_main_force(
     ):
         workflow.run_main()
         _assert_files_copied(workflow.dpath_pipeline, dpath_installed)
+
+
+@pytest.mark.no_xdist
+def test_run_main_same_directory(
+    workflow: PipelineInstallWorkflow,
+    pipeline_config: ProcessingPipelineConfig,
+    caplog: pytest.LogCaptureFixture,
+):
+    dpath_installed = workflow.study.layout.get_dpath_pipeline_bundle(
+        pipeline_config.PIPELINE_TYPE,
+        pipeline_config.NAME,
+        pipeline_config.VERSION,
+    )
+    workflow.run_main()
+
+    workflow.dpath_pipeline = dpath_installed
+    caplog.clear()
+
+    workflow.run_main()
+
+    _assert_files_copied(workflow.source, dpath_installed)
+    assert any(
+        (
+            "Source and destination are the same directory; "
+            "skipping pipeline file operations. Editing an installed pipeline "
+            "in place is not recommended, as accidental changes can compromise "
+            "reproducibility. Keep pipeline development separate from the "
+            "installed copy."
+        )
+        in record.message
+        and record.levelno == logging.WARNING
+        for record in caplog.records
+    )
 
 
 def test_run_main_invalid_zenodo_record(workflow_zenodo: PipelineInstallWorkflow):


### PR DESCRIPTION
…cation.

<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->

<!-- Add issue number -->
- Closes #1041
<!-- - Related to # -->

<!-- Summarize proposed changes below -->
## Changes
- Only perform fileops when target installation location is different from source.
- Issue warning, otherwise.

<!-- DO NOT EDIT OR REMOVE -->
## Checklist
_This section is for the PR reviewer_

### All PRs
- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

### If new feature
- [ ] Tests have been added

### If bug fix
- [ ] There is at least one test that would fail under the original bug conditions


<!-- readthedocs-preview nipoppy start -->
----
📚 Documentation preview 📚: https://nipoppy--1134.org.readthedocs.build/en/1134/

<!-- readthedocs-preview nipoppy end -->